### PR TITLE
Update Helm provider to v3

### DIFF
--- a/kubernetes/provider.tf
+++ b/kubernetes/provider.tf
@@ -18,7 +18,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9.0"
+      version = ">= 3.0.1"
     }
   }
 }
@@ -41,7 +41,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host               = "https://130.61.64.164:6443"
     insecure           = "true"
     client_certificate = base64decode(var.kube_client_cert)


### PR DESCRIPTION
## Summary
- update Helm provider constraint to 3.0.1
- adjust Helm provider block for v3 syntax

## Testing
- `terraform init -upgrade` *(fails: Failed to request discovery document)*

------
https://chatgpt.com/codex/tasks/task_e_68568ae6005c8332b543d5590e81e297