### PR TITLE
Add module README files

### DIFF
--- a/terraform-modules/argo-cd/README.md
+++ b/terraform-modules/argo-cd/README.md
@@ -1,0 +1,15 @@
+# Argo CD Module
+
+## Purpose
+Installs Argo CD and an application set to bootstrap other resources on the Kubernetes cluster.
+
+## Required Variables
+This module has no required variables.
+
+## Example Usage
+```hcl
+module "argo-cd" {
+  source     = "../terraform-modules/argo-cd"
+  depends_on = [module.cert-manager, module.external-dns]
+}
+```

--- a/terraform-modules/cert-manager/README.md
+++ b/terraform-modules/cert-manager/README.md
@@ -1,0 +1,15 @@
+# Cert-Manager Module
+
+## Purpose
+Deploys the cert-manager helm chart and sets up Let's Encrypt issuers for obtaining TLS certificates. Also provisions a Cloudflare API token secret for DNS challenges.
+
+## Required Variables
+- `cloudflare_api_token` - API token with permissions to manage DNS records in Cloudflare.
+
+## Example Usage
+```hcl
+module "cert-manager" {
+  source               = "../terraform-modules/cert-manager"
+  cloudflare_api_token = var.cloudflare_api_token
+}
+```

--- a/terraform-modules/external-dns/README.md
+++ b/terraform-modules/external-dns/README.md
@@ -1,0 +1,16 @@
+# External DNS Module
+
+## Purpose
+Installs ExternalDNS to manage DNS records for Kubernetes resources using Cloudflare.
+
+## Required Variables
+- `cloudflare_api_token` - API token allowing DNS record modifications.
+
+## Example Usage
+```hcl
+module "external-dns" {
+  source               = "../terraform-modules/external-dns"
+  cloudflare_api_token = var.cloudflare_api_token
+  depends_on           = [module.cert-manager]
+}
+```

--- a/terraform-modules/ingress-nginx/README.md
+++ b/terraform-modules/ingress-nginx/README.md
@@ -1,0 +1,14 @@
+# Ingress NGINX Module
+
+## Purpose
+Deploys the Kubernetes Ingress NGINX controller to route HTTP/HTTPS traffic within the cluster.
+
+## Required Variables
+This module has no required variables.
+
+## Example Usage
+```hcl
+module "ingress-nginx" {
+  source = "../terraform-modules/ingress-nginx"
+}
+```

--- a/terraform-modules/metallb/README.md
+++ b/terraform-modules/metallb/README.md
@@ -1,0 +1,14 @@
+# MetalLB Module
+
+## Purpose
+Installs MetalLB to provide LoadBalancer functionality for clusters without a cloud provider.
+
+## Required Variables
+This module has no required variables.
+
+## Example Usage
+```hcl
+module "metallb" {
+  source = "../terraform-modules/metallb"
+}
+```


### PR DESCRIPTION
## Summary
- document each Terraform module with purpose, required variables, and example usage

## Testing
- `terraform -chdir=gcp fmt -check`
- `terraform -chdir=kubernetes fmt -check`
- `terraform -chdir=terraform-modules/cert-manager fmt -check`
- `terraform -chdir=terraform-modules/external-dns fmt -check`
- `terraform -chdir=terraform-modules/ingress-nginx fmt -check`
- `terraform -chdir=terraform-modules/metallb fmt -check`


------
https://chatgpt.com/codex/tasks/task_e_68568fb84a188332bdd226ee9a548352