### PR TITLE
Parameterize GCP TF settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ My Homelab is a mix of Oracle Cloud Infrastructure and three Raspberry Pis. The 
 ## GCP
 - GCP SA Key is added as a environment variable in Terraform Cloud so that Terraform can access GCP infra
 - The username for SSH login is the username provided in the public key in gcp/compute.tf under "ssh-keys". Can be set to any username desired
+- The `gcp/variables.tf` file defines variables for `project`, `region`, `zone`, and `machine_type` to customize the deployment
 
 ## Networking
 - K3S installs by default the Traefik networking and ingress controller. Traefik takes care of exposing Services of type LoadBalancer on the RPi with the RPi private IP. It also is able to route HTTP traffic to the right Ingress. Basically it can do what ingress-nginx and metallb together so I removed them in order to simplify the setup

--- a/gcp/compute.tf
+++ b/gcp/compute.tf
@@ -1,7 +1,7 @@
 resource "google_compute_instance" "gcp1" {
   name         = "gcp1"
-  machine_type = "e2-micro"
-  zone         = "us-central1-c"
+  machine_type = var.machine_type
+  zone         = var.zone
 
   boot_disk {
     initialize_params {

--- a/gcp/provider.tf
+++ b/gcp/provider.tf
@@ -9,6 +9,6 @@ terraform {
 }
 
 provider "google" {
-  project = "spice-385121"
-  region  = "us-central1"
+  project = var.project
+  region  = var.region
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -1,0 +1,24 @@
+variable "project" {
+  description = "GCP project to deploy resources"
+  type        = string
+  default     = "spice-385121"
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP zone"
+  type        = string
+  default     = "us-central1-c"
+}
+
+variable "machine_type" {
+  description = "Instance machine type"
+  type        = string
+  default     = "e2-micro"
+}
+


### PR DESCRIPTION
## Summary
- allow customizing GCP project and region
- support machine type and zone variables
- document new Terraform variables

## Testing
- `terraform fmt -check -recursive gcp`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: no provider packages cached)*

------
https://chatgpt.com/codex/tasks/task_e_68568fb4c47483329a680ecf3abc67e3