### PR TITLE
Parameterize GCP SSH access

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ My Homelab is a mix of Oracle Cloud Infrastructure and three Raspberry Pis. The 
 
 ## GCP
 - GCP SA Key is added as a environment variable in Terraform Cloud so that Terraform can access GCP infra
-- The username for SSH login is the username provided in the public key in gcp/compute.tf under "ssh-keys". Can be set to any username desired
-- The `gcp/variables.tf` file defines variables for `project`, `region`, `zone`, and `machine_type` to customize the deployment
+- The `ssh_username` and `ssh_public_key` variables define the login user and SSH key used for the instance
+- The `gcp/variables.tf` file defines variables for `project`, `region`, `zone`, `machine_type`, `ssh_username`, and `ssh_public_key` to customize the deployment
 
 ## Networking
 - K3S installs by default the Traefik networking and ingress controller. Traefik takes care of exposing Services of type LoadBalancer on the RPi with the RPi private IP. It also is able to route HTTP traffic to the right Ingress. Basically it can do what ingress-nginx and metallb together so I removed them in order to simplify the setup

--- a/gcp/compute.tf
+++ b/gcp/compute.tf
@@ -12,9 +12,7 @@ resource "google_compute_instance" "gcp1" {
   }
 
   metadata = {
-    "ssh-keys" = <<EOT
-      dev:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ5Ysv6PF3HbWQ/JfP2vWEBHtH8wPv6ysbyosEREXpO3 dev
-     EOT
+    "ssh-keys" = "${var.ssh_username}:${var.ssh_public_key} ${var.ssh_username}"
   }
 
   network_interface {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -22,3 +22,15 @@ variable "machine_type" {
   default     = "e2-micro"
 }
 
+variable "ssh_username" {
+  description = "Username for SSH login"
+  type        = string
+  default     = "dev"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for the instance"
+  type        = string
+  default     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ5Ysv6PF3HbWQ/JfP2vWEBHtH8wPv6ysbyosEREXpO3"
+}
+


### PR DESCRIPTION
## Summary
- add variables for the VM ssh username and public key
- replace hard-coded ssh info in GCP compute instance
- document new variables

## Testing
- `pre-commit run --files gcp/compute.tf gcp/variables.tf README.md` *(fails: yaml formatting issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6857c20a659083328aa844df614b1466