### PR TITLE
Ensure K3S setup runs only on main

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -193,6 +193,7 @@ jobs:
   k3s-setup:
     name: "Setup K3S Cluster"
     needs: [tailscale-setup]
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && github.event_name == 'push') }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- avoid applying `k3s.yml` for pull requests by gating the job

## Testing
- `pre-commit run --files .github/workflows/actions.yml` *(fails: line length, trailing spaces)*

------
https://chatgpt.com/codex/tasks/task_e_6857e1848c58833287b6485d82de9cf5