### PR TITLE
Ensure apt upgrades run non-interactively for k3s cluster setup

### DIFF
--- a/ansible/k3s.yml
+++ b/ansible/k3s.yml
@@ -11,6 +11,10 @@
       ansible.builtin.apt:
         update_cache: true
         upgrade: dist
+        dpkg_options:
+          - "force-confdef"
+          - "force-confold"
+        force_apt_get: true
 
     - name: Downloading k3s script
       ansible.builtin.get_url:


### PR DESCRIPTION
## Summary
- force the apt upgrade task to use apt-get with non-interactive dpkg options so it does not hang on prompts during cluster setup

## Testing
- ansible-lint ansible/k3s.yml *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0375dec5883329fe5473ff9a12b65