### PR TITLE
Add template for Cloudflare-backed Let's Encrypt ClusterIssuer

### DIFF
--- a/kubernetes/cluster.tf
+++ b/kubernetes/cluster.tf
@@ -11,6 +11,14 @@ module "cert-manager" {
   count = 1
 }
 
+resource "kubernetes_manifest" "letsencrypt_prod_clusterissuer" {
+  manifest = yamldecode(templatefile("${path.module}/clusterissuer-letsencrypt-prod.yaml", {
+    email = var.letsencrypt_prod_email
+  }))
+
+  depends_on = [module.cert-manager]
+}
+
 module "external-dns" {
   source               = "../terraform-modules/external-dns"
   cloudflare_api_token = var.cloudflare_api_token

--- a/kubernetes/clusterissuer-letsencrypt-prod.yaml
+++ b/kubernetes/clusterissuer-letsencrypt-prod.yaml
@@ -1,0 +1,21 @@
+# ClusterIssuer for issuing certificates for shrub.dev via Let's Encrypt DNS-01 validation
+# Update the email field with the address registered with Let's Encrypt before applying.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: admin@shrub.dev
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token-secret
+              key: api-token
+        selector:
+          dnsZones:
+            - shrub.dev

--- a/kubernetes/clusterissuer-letsencrypt-prod.yaml
+++ b/kubernetes/clusterissuer-letsencrypt-prod.yaml
@@ -1,12 +1,11 @@
 # ClusterIssuer for issuing certificates for shrub.dev via Let's Encrypt DNS-01 validation
-# Update the email field with the address registered with Let's Encrypt before applying.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
 spec:
   acme:
-    email: admin@shrub.dev
+    email: ${email}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: letsencrypt-prod

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -8,6 +8,15 @@ variable "cloudflare_api_token" {
   }
 }
 
+variable "letsencrypt_prod_email" {
+  description = "Email address registered with Let's Encrypt for the production ClusterIssuer"
+  type        = string
+  validation {
+    condition     = can(regex("^[^@]+@[^@]+\.[^@]+$", var.letsencrypt_prod_email))
+    error_message = "letsencrypt_prod_email must be a valid email address."
+  }
+}
+
 # Raspberry Pi variables
 variable "kube_client_cert" {
   description = "Rpi Kube cluster certificate base64 encoded"


### PR DESCRIPTION
## Summary
- add a Kubernetes manifest template for the letsencrypt-prod ClusterIssuer that uses the Cloudflare DNS solver for shrub.dev

## Testing
- pre-commit run --files kubernetes/clusterissuer-letsencrypt-prod.yaml

------
https://chatgpt.com/codex/tasks/task_e_68d03be1be8c83329c800ff6d3c6cf4b