### PR TITLE
fix: clean up ansible inventory warnings

### DIFF
--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -1,18 +1,18 @@
 [vpn]
-pam-amd1 ansible_host=130.61.64.164 ansible_user=ubuntu
+pam-amd1 ansible_host=130.61.64.164 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3.10
 # Strict host key checking has to be disabled as cretus is accessed using an SSH tunnel and Github is not able to fetch it's public key using ssh-keyscan
-michael-pi ansible_host=100.100.1.100 ansible_user=akash ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+michael-pi ansible_host=100.100.1.100 ansible_user=akash ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3.11
 
-[pi-workers]
-jim-pi ansible_host=100.100.1.101 ansible_user=akash ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+[pi_workers]
+jim-pi ansible_host=100.100.1.101 ansible_user=akash ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3.11
 
-[oracle-workers]
-stanley-arm1 ansible_host=130.162.225.255 ansible_user=ubuntu
-phyllis-arm2 ansible_host=138.2.130.168 ansible_user=ubuntu
-angela-amd2 ansible_host=130.61.63.188 ansible_user=ubuntu
+[oracle_workers]
+stanley-arm1 ansible_host=130.162.225.255 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3.10
+phyllis-arm2 ansible_host=138.2.130.168 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3.10
+angela-amd2 ansible_host=130.61.63.188 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3.10
 
-[gcp-workers]
-toby-gcp1 ansible_host=34.28.187.2 ansible_user=dev
+[gcp_workers]
+toby-gcp1 ansible_host=34.28.187.2 ansible_user=dev ansible_python_interpreter=/usr/bin/python3.10
 
-[pihole-worker]
-dwight-pi ansible_host=100.100.1.102 ansible_user=cretus ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+[pihole_worker]
+dwight-pi ansible_host=100.100.1.102 ansible_user=cretus ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ansible_python_interpreter=/usr/bin/python3.9

--- a/ansible/vpn.yml
+++ b/ansible/vpn.yml
@@ -50,10 +50,10 @@
 - name: Install and Configure Tailscale
   hosts:
     - vpn
-    - pi-workers
-    - oracle-workers
-    - gcp-workers
-    - dwight-pi
+    - pi_workers
+    - oracle_workers
+    - gcp_workers
+    - pihole_worker
   become: true
   vars:
     tailscale_version: "latest"


### PR DESCRIPTION
## Summary
- rename hyphenated Ansible inventory groups and update playbook references to avoid invalid character warnings
- pin the Python interpreter path for each host to prevent Ansible discovery warnings

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfb7660d088332a3a65b2134d4cabd