### PR TITLE
feat: gate kubernetes apply behind manual approval

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -451,6 +451,8 @@ jobs:
         working-directory: ./kubernetes
     env:
       TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+    outputs:
+      plan_exitcode: ${{ steps.plan.outputs.exitcode }}
     steps:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3.1.2
@@ -523,34 +525,43 @@ jobs:
 
       - name: "Terraform Plan"
         id: plan
-        run: terraform plan -no-color
-
-      - name: Terraform Apply
-        id: apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: terraform apply -auto-approve -input=false
-      - name: Terraform Apply Summary
-        if: always()
         run: |
-          if [ "${{ steps.apply.outcome }}" = "success" ]; then
-            echo "Terraform apply succeeded." >> $GITHUB_STEP_SUMMARY
-          else
-            echo "Terraform apply failed." >> $GITHUB_STEP_SUMMARY
+          set +e
+          terraform plan -no-color -detailed-exitcode -out=plan.tfplan
+          PLAN_EXIT=$?
+          set -e
+          echo "exitcode=$PLAN_EXIT" >> $GITHUB_OUTPUT
+          if [ "$PLAN_EXIT" -eq 1 ]; then
+            exit 1
           fi
 
-      # Add drift detection
-      - name: Check for Infrastructure Drift
-        id: drift_check
+      - name: Terraform Plan Outcome
         run: |
-          terraform plan -detailed-exitcode -out=plan.tfplan
-          echo "drift_exitcode=$?" >> $GITHUB_OUTPUT
-      - name: Drift Detection Summary
-        if: always()
-        run: |
-          echo "Drift detection exit code: ${{ steps.drift_check.outputs.drift_exitcode }}" >> $GITHUB_STEP_SUMMARY
+          case "${PLAN_EXITCODE}" in
+            0)
+              echo "Terraform plan detected no changes." >> $GITHUB_STEP_SUMMARY
+              ;;
+            2)
+              echo "Terraform plan detected pending changes." >> $GITHUB_STEP_SUMMARY
+              ;;
+            *)
+              echo "Terraform plan exited with code ${PLAN_EXITCODE}." >> $GITHUB_STEP_SUMMARY
+              ;;
+          esac
+        env:
+          PLAN_EXITCODE: ${{ steps.plan.outputs.exitcode }}
+
+      - name: Upload Terraform Plan Artifact
+        if: steps.plan.outputs.exitcode == '2'
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-k3s-plan
+          path: plan.tfplan
+          retention-days: 5
+
       # Add plan summary for PRs
       - name: Terraform Plan Summary
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.plan.outputs.exitcode != '1'
         run: |
           echo "## Terraform Plan Summary" >> $GITHUB_STEP_SUMMARY
           ADDED=$(terraform show -json plan.tfplan | jq '.resource_changes | map(select(.change.actions[0] == "create")) | length')
@@ -559,3 +570,73 @@ jobs:
           echo "* Resources to add: ${ADDED}" >> $GITHUB_STEP_SUMMARY
           echo "* Resources to change: ${CHANGED}" >> $GITHUB_STEP_SUMMARY
           echo "* Resources to destroy: ${DESTROYED}" >> $GITHUB_STEP_SUMMARY
+      - name: Terraform Plan Details
+        if: steps.plan.outputs.exitcode != '1'
+        run: |
+          {
+            echo "## Terraform Plan Details"
+            echo '```'
+            terraform show -no-color plan.tfplan
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
+  run-k3s-apply:
+    name: "Apply Kubernetes Cluster"
+    needs: run-k3s
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.run-k3s.outputs.plan_exitcode == '2'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    defaults:
+      run:
+        working-directory: ./kubernetes
+    env:
+      TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+    steps:
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3.1.2
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Cache Terraform plugins
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: ${{ runner.os }}-terraform-${{ hashFiles('kubernetes/**/*.tf') }}
+          restore-keys: |
+            ${{ runner.os }}-terraform-
+
+      - name: Download Terraform Plan
+        uses: actions/download-artifact@v4
+        with:
+          name: run-k3s-plan
+          path: kubernetes
+
+      - name: Setup Terraform variables
+        run: |-
+          cat > terraform.tfvars <<EOF
+          cloudflare_api_token = "${{ secrets.TF_CLOUDFLARE_API_TOKEN }}"
+          kube_client_cert = "${{ secrets.TF_KUBE_CLIENT_CERT }}"
+          kube_client_key = "${{ secrets.TF_KUBE_CLIENT_KEY }}"
+          EOF
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Apply
+        id: apply
+        run: terraform apply -auto-approve -input=false plan.tfplan
+
+      - name: Terraform Apply Summary
+        if: always()
+        run: |
+          if [ "${{ steps.apply.outcome }}" = "success" ]; then
+            echo "Terraform apply succeeded." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Terraform apply failed." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary
- expose the run-k3s Terraform plan output and details in the workflow summary while saving the compiled plan as an artifact
- capture the plan exit code so the workflow can detect pending changes and publish the plan for review
- add a dedicated apply job that runs only on pushes to main, requires environment approval, and reuses the saved plan for terraform apply

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e0e4a1f0d0833280f69637c8bc3a38