### PR TITLE
Fix conditional syntax in run-k3s apply workflow job

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -589,10 +589,11 @@ jobs:
   run-k3s-apply:
     name: "Apply Kubernetes Cluster"
     needs: run-k3s
-    if: needs.run-k3s.outputs.plan_exitcode == '2' && (
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_kubernetes_apply == 'true')
-    )
+    if: >-
+      ${{ needs.run-k3s.outputs.plan_exitcode == '2' && (
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_kubernetes_apply == 'true')
+        ) }}
     runs-on: ubuntu-latest
     environment:
       name: production


### PR DESCRIPTION
## Summary
- wrap the run-k3s-apply job condition in a GitHub Actions expression to fix YAML syntax errors
- format the condition with a folded scalar to satisfy yamllint line length limits

## Testing
- pre-commit run --files .github/workflows/actions.yml *(fails: ansible-lint requires the ansible.posix collection on the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68e10852e82483328f96cd5b77c95bc8