### PR TITLE
refactor: create reusable composite action for pre-commit setup

### DIFF
--- a/.github/actions/setup-precommit/action.yml
+++ b/.github/actions/setup-precommit/action.yml
@@ -1,0 +1,41 @@
+---
+name: 'Setup and Run Pre-commit'
+description: 'Install pre-commit, cache it, and run checks on changed files'
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache pip downloads
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('.pre-commit-config.yaml', 'ansible/requirements.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install pre-commit
+      shell: bash
+      run: |
+        python3 -m pip install --upgrade pip
+        pip3 install pre-commit
+
+    - name: Cache pre-commit environments
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - name: Run pre-commit
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+        else
+          BASE_SHA="${{ github.event.before }}"
+        fi
+        CHANGED_FILES=$(git diff --name-only --diff-filter=ACM "$BASE_SHA" "${{ github.sha }}")
+        if [ -n "$CHANGED_FILES" ]; then
+          pre-commit run --files "$CHANGED_FILES" --hook-stage manual
+        else
+          pre-commit run --hook-stage manual --hook-id terraform_fmt terraform_validate
+        fi
+

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -39,38 +39,8 @@ jobs:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.9.6"  # Pin Terraform version
 
-      - name: Cache pip downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.pre-commit-config.yaml', 'ansible/requirements.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install pre-commit
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Run pre-commit
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE_SHA="${{ github.event.before }}"
-          fi
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACM "$BASE_SHA" "${{ github.sha }}")
-          if [ -n "$CHANGED_FILES" ]; then
-            pre-commit run --files "$CHANGED_FILES" --hook-stage manual
-          else
-            pre-commit run --hook-stage manual --hook-id terraform_fmt terraform_validate
-          fi
+      - name: Setup and Run Pre-commit
+        uses: ./.github/actions/setup-precommit
 
       # Add caching for Terraform plugins
       - name: Cache Terraform plugins
@@ -164,38 +134,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache pip downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.pre-commit-config.yaml', 'ansible/requirements.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install pre-commit
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Run pre-commit
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE_SHA="${{ github.event.before }}"
-          fi
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACM "$BASE_SHA" "${{ github.sha }}")
-          if [ -n "$CHANGED_FILES" ]; then
-            pre-commit run --files "$CHANGED_FILES" --hook-stage manual
-          else
-            pre-commit run --hook-stage manual --hook-id terraform_fmt terraform_validate
-          fi
+      - name: Setup and Run Pre-commit
+        uses: ./.github/actions/setup-precommit
 
       - name: Cache Terraform plugins
         uses: actions/cache@v4
@@ -296,28 +236,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: ansible-galaxy collection install -r ansible/requirements.yml --force
 
-      - name: Install pre-commit
-        run: pip3 install pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Run pre-commit
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE_SHA="${{ github.event.before }}"
-          fi
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACM "$BASE_SHA" "${{ github.sha }}")
-          if [ -n "$CHANGED_FILES" ]; then
-            pre-commit run --files "$CHANGED_FILES" --hook-stage manual
-          else
-            pre-commit run --hook-stage manual --hook-id terraform_fmt terraform_validate
-          fi
+      - name: Setup and Run Pre-commit
+        uses: ./.github/actions/setup-precommit
 
       - name: Run ansible-lint.
         run: ansible-lint
@@ -402,28 +322,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: ansible-galaxy collection install -r ansible/requirements.yml --force
 
-      - name: Install pre-commit
-        run: pip3 install pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Run pre-commit
-        run: |
-            if [ "${{ github.event_name }}" = "pull_request" ]; then
-              BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            else
-              BASE_SHA="${{ github.event.before }}"
-            fi
-            CHANGED_FILES=$(git diff --name-only --diff-filter=ACM "$BASE_SHA" "${{ github.sha }}")
-            if [ -n "$CHANGED_FILES" ]; then
-              pre-commit run --files "$CHANGED_FILES" --hook-stage manual
-            else
-              pre-commit run --all-files
-            fi
+      - name: Setup and Run Pre-commit
+        uses: ./.github/actions/setup-precommit
 
       - name: Run ansible-lint.
         run: ansible-lint
@@ -479,38 +379,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache pip downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.pre-commit-config.yaml', 'ansible/requirements.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install pre-commit
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Run pre-commit
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE_SHA="${{ github.event.before }}"
-          fi
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACM "$BASE_SHA" "${{ github.sha }}")
-          if [ -n "$CHANGED_FILES" ]; then
-            pre-commit run --files "$CHANGED_FILES" --hook-stage manual
-          else
-            pre-commit run --hook-stage manual --hook-id terraform_fmt terraform_validate
-          fi
+      - name: Setup and Run Pre-commit
+        uses: ./.github/actions/setup-precommit
 
       - name: Cache Terraform plugins
         uses: actions/cache@v4


### PR DESCRIPTION
Extract common pre-commit installation and execution logic into a reusable composite action to eliminate duplication across all jobs (gcp-setup, oracle-setup, tailscale-setup, k3s-setup, run-k3s).

The composite action:
- Installs and caches pip dependencies
- Installs pre-commit
- Caches pre-commit environments
- Runs pre-commit on changed files (or specific terraform hooks as fallback)

This significantly reduces code duplication and makes pre-commit configuration more maintainable across the workflow.