### PR TITLE
refactor: create reusable composite action for SSH setup

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -1,0 +1,34 @@
+---
+name: 'Setup SSH'
+description: 'Configure SSH with private key and disable strict host checking'
+inputs:
+  ssh_private_key:
+    description: 'SSH private key for authentication'
+    required: true
+  ansible_vault_password:
+    description: 'Ansible vault password (optional, only needed for Ansible jobs)'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup SSH
+      shell: bash
+      run: |
+        eval `ssh-agent -s`
+        mkdir -p /home/runner/.ssh/
+        touch /home/runner/.ssh/id_rsa
+        # Create the SSH Private Key used to connect to all the servers using the Secret
+        echo -e "${{ inputs.ssh_private_key }}" > /home/runner/.ssh/id_rsa
+        chmod 600 /home/runner/.ssh/id_rsa
+        # Disable strict host key checking
+        echo -e "Host *\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile=/dev/null\n" > /home/runner/.ssh/config
+
+    - name: Setup Ansible Vault
+      if: inputs.ansible_vault_password != ''
+      shell: bash
+      working-directory: ${{ github.workspace }}/ansible
+      run: |
+        # Create the Ansible Vault password file for decryption
+        echo -e "${{ inputs.ansible_vault_password }}" > ./vault.pass
+

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -323,18 +323,10 @@ jobs:
         run: ansible-lint
 
       - name: Setup SSH
-        shell: bash
-        run: |
-         eval `ssh-agent -s`
-         mkdir -p /home/runner/.ssh/
-         touch /home/runner/.ssh/id_rsa
-         # Create the SSH Private Key used to connect to all the servers using the Secret
-         echo -e "${{secrets.SSH_AUTH_PRIVATE_KEY}}" > /home/runner/.ssh/id_rsa
-         # Create the Ansible Vault password file for decryption
-         echo -e "${{secrets.ANSIBLE_VAULT_PASSWORD}}" > ./vault.pass
-         chmod 700 /home/runner/.ssh/id_rsa
-         # Disable strict host key checking
-         echo -e "Host *\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile=/dev/null\n" > /home/runner/.ssh/config
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh_private_key: ${{ secrets.SSH_AUTH_PRIVATE_KEY }}
+          ansible_vault_password: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 
       - name: Run vpn-playbook
         id: vpn_playbook
@@ -429,18 +421,10 @@ jobs:
         run: ansible-lint
 
       - name: Setup SSH
-        shell: bash
-        run: |
-         eval `ssh-agent -s`
-         mkdir -p /home/runner/.ssh/
-         touch /home/runner/.ssh/id_rsa
-         # Create the SSH Private Key used to connect to all the servers using the Secret
-         echo -e "${{secrets.SSH_AUTH_PRIVATE_KEY}}" > /home/runner/.ssh/id_rsa
-         # Create the Ansible Vault password file for decryption
-         echo -e "${{secrets.ANSIBLE_VAULT_PASSWORD}}" > ./vault.pass
-         chmod 700 /home/runner/.ssh/id_rsa
-         # Disable strict host key checking
-         echo -e "Host *\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile=/dev/null\n" > /home/runner/.ssh/config
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh_private_key: ${{ secrets.SSH_AUTH_PRIVATE_KEY }}
+          ansible_vault_password: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 
       - name: Run k3s-playbook
         id: k3s_playbook


### PR DESCRIPTION
Extract common SSH setup logic into a reusable composite action to eliminate duplication across tailscale-setup and k3s-setup jobs.

The composite action:
- Configures SSH with the private key and appropriate permissions (600)
- Disables strict host key checking
- Optionally sets up Ansible vault password file when provided

This reduces code duplication and makes SSH configuration more maintainable across the workflow.