### PR TITLE
refactor: simplify run-k3s job dependencies

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -460,7 +460,7 @@ jobs:
 
   run-k3s:
     name: "Terraform K8S"
-    needs: [tailscale-setup, k3s-setup]
+    needs: [k3s-setup]
     if: ${{ github.ref != 'refs/heads/staging' }}
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
Remove redundant tailscale-setup dependency from run-k3s job since k3s-setup already depends on tailscale-setup. This creates a cleaner dependency chain: tailscale-setup -> k3s-setup -> run-k3s.