### PR TITLE
fix: make pre-commit fallback logic consistent across jobs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -422,7 +422,7 @@ jobs:
             if [ -n "$CHANGED_FILES" ]; then
               pre-commit run --files "$CHANGED_FILES" --hook-stage manual
             else
-              pre-commit run --all-files
+              pre-commit run --hook-stage manual --hook-id terraform_fmt terraform_validate
             fi
 
       - name: Run ansible-lint.


### PR DESCRIPTION
The k3s-setup job was using '--all-files' as a fallback when no files changed, while all other jobs use specific terraform hooks. This makes the k3s-setup job consistent with the pattern used in gcp-setup, oracle-setup, and run-k3s jobs.