### PR TITLE
feat: add Terraform plan artifacts for oracle and kubernetes jobs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -231,6 +231,15 @@ jobs:
         id: plan
         run: terraform plan -no-color -out=plan.tfplan
 
+      # Save plan as artifact for review
+      - name: Save Terraform Plan
+        uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
+        with:
+          name: oracle-terraform-plan
+          path: ./oracle/plan.tfplan
+          retention-days: 5
+
       - name: Terraform Apply
         id: apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -542,6 +551,15 @@ jobs:
       - name: "Terraform Plan"
         id: plan
         run: terraform plan -no-color -out=plan.tfplan
+
+      # Save plan as artifact for review
+      - name: Save Terraform Plan
+        uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
+        with:
+          name: kubernetes-terraform-plan
+          path: ./kubernetes/plan.tfplan
+          retention-days: 5
 
       - name: Terraform Apply
         id: apply


### PR DESCRIPTION
Add plan artifact uploads for oracle-setup and run-k3s jobs to match the existing pattern in gcp-setup. This allows reviewers to examine Terraform plans during pull request reviews.

Plans are saved for 5 days and only uploaded for pull requests.