### PR TITLE
perf: add path filters to skip security scans for non-code changes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,8 +4,20 @@ run-name: Security scan
 on:
   push:
     branches: [main, staging]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'AGENTS.md'
+      - 'archive/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'AGENTS.md'
+      - 'archive/**'
   schedule:
     # Run security scans daily at 2 AM UTC
     - cron: '0 2 * * *'


### PR DESCRIPTION
Skip security scans when only documentation or metadata files change. This prevents unnecessary workflow runs for:
- Markdown files (README, docs)
- LICENSE
- .gitignore
- AGENTS.md
- archive/** (legacy assets)

Scheduled scans and workflow_dispatch still run on all files to maintain comprehensive security coverage.