### PR TITLE
perf: add concurrency control to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,11 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+# Cancel in-progress security scans for the same PR/branch to save resources
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   security-scan:
     name: Security Vulnerability Scan


### PR DESCRIPTION
Cancel in-progress security scans when new commits are pushed to the same PR or branch. This prevents wasting compute resources on outdated code while maintaining security coverage.

For example, if 3 commits are pushed to a PR in quick succession, only the latest scan will complete, saving ~2-3 minutes per cancelled run.