### PR TITLE
refactor: use TF_VAR_ environment variables instead of terraform.tfva…

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -99,6 +99,12 @@ jobs:
         working-directory: ./oracle
     env:
       TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+      TF_VAR_user_ocid: ${{ secrets.TF_USER_OCID }}
+      TF_VAR_tenancy_ocid: ${{ secrets.TF_TENANCY_OCID }}
+      TF_VAR_ssh_authorized_keys: ${{ secrets.TF_SSH_AUTHORIZED_KEYS }}
+      TF_VAR_oci_private_key: ${{ secrets.TF_OCI_PRIVATE_KEY }}
+      TF_VAR_fingerprint: ${{ secrets.TF_FINGERPRINT }}
+      TF_VAR_compartment_id: ${{ secrets.TF_COMPARTMENT_ID }}
     steps:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3.1.2
@@ -133,25 +139,11 @@ jobs:
 
       - name: "Terraform Plan"
         id: plan
-        env:
-          TF_VAR_user_ocid: ${{ secrets.TF_USER_OCID }}
-          TF_VAR_tenancy_ocid: ${{ secrets.TF_TENANCY_OCID }}
-          TF_VAR_ssh_authorized_keys: ${{ secrets.TF_SSH_AUTHORIZED_KEYS }}
-          TF_VAR_oci_private_key: ${{ secrets.TF_OCI_PRIVATE_KEY }}
-          TF_VAR_fingerprint: ${{ secrets.TF_FINGERPRINT }}
-          TF_VAR_compartment_id: ${{ secrets.TF_COMPARTMENT_ID }}
         run: terraform plan -no-color -out=plan.tfplan
 
       - name: Terraform Apply
         id: apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        env:
-          TF_VAR_user_ocid: ${{ secrets.TF_USER_OCID }}
-          TF_VAR_tenancy_ocid: ${{ secrets.TF_TENANCY_OCID }}
-          TF_VAR_ssh_authorized_keys: ${{ secrets.TF_SSH_AUTHORIZED_KEYS }}
-          TF_VAR_oci_private_key: ${{ secrets.TF_OCI_PRIVATE_KEY }}
-          TF_VAR_fingerprint: ${{ secrets.TF_FINGERPRINT }}
-          TF_VAR_compartment_id: ${{ secrets.TF_COMPARTMENT_ID }}
         run: terraform apply -auto-approve -input=false
 
       - name: Terraform Apply Summary
@@ -333,6 +325,9 @@ jobs:
         working-directory: ./kubernetes
     env:
       TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+      TF_VAR_cloudflare_api_token: ${{ secrets.TF_CLOUDFLARE_API_TOKEN }}
+      TF_VAR_kube_client_cert: ${{ secrets.TF_KUBE_CLIENT_CERT }}
+      TF_VAR_kube_client_key: ${{ secrets.TF_KUBE_CLIENT_KEY }}
     steps:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3.1.2
@@ -367,19 +362,11 @@ jobs:
 
       - name: "Terraform Plan"
         id: plan
-        env:
-          TF_VAR_cloudflare_api_token: ${{ secrets.TF_CLOUDFLARE_API_TOKEN }}
-          TF_VAR_kube_client_cert: ${{ secrets.TF_KUBE_CLIENT_CERT }}
-          TF_VAR_kube_client_key: ${{ secrets.TF_KUBE_CLIENT_KEY }}
         run: terraform plan -no-color -out=plan.tfplan
 
       - name: Terraform Apply
         id: apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        env:
-          TF_VAR_cloudflare_api_token: ${{ secrets.TF_CLOUDFLARE_API_TOKEN }}
-          TF_VAR_kube_client_cert: ${{ secrets.TF_KUBE_CLIENT_CERT }}
-          TF_VAR_kube_client_key: ${{ secrets.TF_KUBE_CLIENT_KEY }}
         run: terraform apply -auto-approve -input=false
 
       - name: Terraform Apply Summary
@@ -395,10 +382,6 @@ jobs:
       - name: Check for Infrastructure Drift
         id: drift_check
         if: github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.apply.outcome == 'success'
-        env:
-          TF_VAR_cloudflare_api_token: ${{ secrets.TF_CLOUDFLARE_API_TOKEN }}
-          TF_VAR_kube_client_cert: ${{ secrets.TF_KUBE_CLIENT_CERT }}
-          TF_VAR_kube_client_key: ${{ secrets.TF_KUBE_CLIENT_KEY }}
         run: |
           # plan exit codes: 0=no change, 1=error, 2=changes (drift)
           set +e


### PR DESCRIPTION
…rs files

Replace heredoc-based terraform.tfvars file creation with TF_VAR_ prefixed environment variables for passing secrets to Terraform. This improves security by not writing sensitive data to disk and follows Terraform best practices.

Changes:
- Oracle setup: Use TF_VAR_ for 6 OCI credentials (user_ocid, tenancy_ocid, ssh_authorized_keys, oci_private_key, fingerprint, compartment_id)
- Kubernetes setup: Use TF_VAR_ for 3 credentials (cloudflare_api_token, kube_client_cert, kube_client_key)
- Applied to plan, apply, and drift detection steps

Benefits:
- No sensitive data written to disk (even temporarily)
- Cleaner workflow syntax
- Follows Terraform native environment variable pattern
- Eliminates risk of accidentally committing .tfvars files