### PR TITLE
feat: add Gitleaks pre-commit hook for secret detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 ---
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.99.4
     hooks:


### PR DESCRIPTION
Add Gitleaks to pre-commit configuration to catch secrets before they are committed to the repository. This provides an additional layer of security alongside the existing TruffleHog scans in CI/CD.

Benefits:
- Catch secrets locally before push
- Fast feedback during development
- Complements CI/CD secret scanning
- Uses latest Gitleaks v8.21.2

Gitleaks will run on every commit and block commits containing secrets, preventing accidental exposure of sensitive data.