### PR TITLE
chore: pin Terraform version across all jobs for consistency

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -110,6 +110,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3.1.2
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_version: "1.9.6"
 
       - name: Checkout
         uses: actions/checkout@v5
@@ -333,6 +334,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3.1.2
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_version: "1.9.6"
 
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Pin terraform_version to 1.9.6 in oracle-setup and run-k3s jobs to match gcp-setup job. This ensures consistent Terraform behavior across all infrastructure deployments and prevents version-related issues.

Benefits:
- Consistent Terraform behavior across all jobs
- Prevents unexpected changes from Terraform version updates
- Matches existing pattern in gcp-setup job
- Easier to update all jobs together when upgrading Terraform