### PR TITLE
fix(ci): use inline base64 cert data in kubeconfig for kubectl

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -943,14 +943,11 @@ jobs:
           webhook_timeout_pattern='failed calling webhook "webhook.cert-manager.io"'
           deadline_exceeded_pattern='context deadline exceeded'
           k8s_api_endpoint="$(awk -F'"' '/k8s_api_endpoint =/ {print $2}' provider.tf)"
-          client_cert_file="$(mktemp)"
-          client_key_file="$(mktemp)"
-          cluster_ca_file="$(mktemp)"
           kubeconfig_file="$(mktemp)"
           log_file=""
 
           cleanup() {
-            rm -f "$client_cert_file" "$client_key_file" "$cluster_ca_file" "$kubeconfig_file"
+            rm -f "$kubeconfig_file"
             if [ -n "$log_file" ]; then
               rm -f "$log_file"
             fi
@@ -958,23 +955,19 @@ jobs:
 
           trap cleanup EXIT
 
-          printf '%s\n' "$TF_VAR_kube_client_cert" > "$client_cert_file"
-          printf '%s\n' "$TF_VAR_kube_client_key" > "$client_key_file"
-          printf '%s\n' "$TF_VAR_kube_cluster_ca_cert" > "$cluster_ca_file"
-
           cat > "$kubeconfig_file" <<EOF
           apiVersion: v1
           kind: Config
           clusters:
             - name: homelab
               cluster:
-                certificate-authority: $cluster_ca_file
+                certificate-authority-data: $TF_VAR_kube_cluster_ca_cert
                 server: $k8s_api_endpoint
           users:
             - name: github-actions
               user:
-                client-certificate: $client_cert_file
-                client-key: $client_key_file
+                client-certificate-data: $TF_VAR_kube_client_cert
+                client-key-data: $TF_VAR_kube_client_key
           contexts:
             - name: homelab
               context:


### PR DESCRIPTION
## Problem
The **Terraform K8S** job has been failing daily since Apr 8 (commit 6e5931b) with:
```
error: unable to load root certificates: unable to parse bytes as PEM block
```

## Root Cause
The cert-manager webhook retry logic (PR #518) builds a kubeconfig for `kubectl`, but uses `certificate-authority:` / `client-certificate:` / `client-key:` fields — which expect **PEM files on disk**.

However, the cert values from SOPS (`kube.yaml`) are **base64-encoded strings**, not raw PEM. Writing base64 to a file and pointing kubectl at it as PEM causes the parse failure.

Terraform itself was unaffected because its provider uses the base64 values directly via `TF_VAR_*` env vars.

## Fix
Switch to `certificate-authority-data` / `client-certificate-data` / `client-key-data` in the kubeconfig, which accept **inline base64** content directly — matching the format stored in SOPS.

Also removes the now-unnecessary temp cert files and simplifies cleanup.