### PR TITLE
chore(k3s): bump k3s from v1.35.0+k3s1 to v1.35.3+k3s1

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,6 +1,6 @@
 ---
 # Managed by Renovate (k3s-io/k3s tags)
-k3s_version: "v1.35.0+k3s1"
+k3s_version: "v1.35.3+k3s1"
 k3s_master_ip: "100.100.1.100"
 k3s_master_port: "6443"
 


### PR DESCRIPTION
Bumps k3s to the latest patch in the v1.35 channel.

**Current:** v1.35.0+k3s1
**Target:** v1.35.3+k3s1

### Notable changes (v1.35.1 → v1.35.3)
- Bump etcd, coredns to 1.14.0, Traefik to v3.6.7
- Rootless ports: add UDP support
- Fix restart of control-plane-only nodes reconciling from local datastore
- Bump local path provisioner to v0.0.34
- Go 1.25.x security updates
- secrets-encrypt enable on existing clusters

Release notes: https://docs.k3s.io/release-notes/v1.35.X