### PR TITLE
fix(argo-cd): disable duplicate Certificate resource causing CI failures

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,15 +127,6 @@
     }
   ],
   "results": {
-    "terraform-modules/argo-cd/values.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "terraform-modules/argo-cd/values.yaml",
-        "hashed_secret": "bfc1b86ce643b65bd540989213254b01fd6ad418",
-        "is_verified": false,
-        "line_number": 51
-      }
-    ],
     "terraform-modules/cert-manager/certificate.yaml": [
       {
         "type": "Secret Keyword",

--- a/terraform-modules/argo-cd/values.yaml
+++ b/terraform-modules/argo-cd/values.yaml
@@ -46,18 +46,12 @@ server:
 
   certificate:
     # -- Deploy a Certificate resource (requires cert-manager)
-    enabled: true
-    # -- The name of the Secret that will be automatically created and managed by this Certificate resource
-    secretName: argocd-server-tls
-    # -- Certificate primary domain (commonName)
-    domain: argo.shrub.dev
-    issuer:
-      # -- Certificate issuer group. Set if using an external issuer. Eg. `cert-manager.io`
-      group: "cert-manager.io"
-      # -- Certificate issuer kind. Either `Issuer` or `ClusterIssuer`
-      kind: "ClusterIssuer"
-      # -- Certificate issuer name. Eg. `letsencrypt`
-      name: "letsencrypt-prod"
+    # Disabled: the Ingress annotation cert-manager.io/cluster-issuer already
+    # creates a Certificate automatically. Having both causes a conflict where
+    # two Certificate resources point to the same Secret (argocd-server-tls),
+    # leaving one permanently in Ready=False and causing webhook timeouts
+    # during Helm upgrades.
+    enabled: false
 
 
 ## The following addons are not really necessarily for a homelab setup


### PR DESCRIPTION
## Problem
Terraform K8S job fails on every run with:
```
Error upgrading chart: cannot patch "argo-cd-argocd-server" with kind Certificate:
failed calling webhook "webhook.cert-manager.io": context deadline exceeded
```

## Root Cause
**Double certificate generation** for ArgoCD TLS:

1. The Ingress annotation `cert-manager.io/cluster-issuer: letsencrypt-prod` with `tls: true` makes cert-manager auto-create a Certificate → `argocd-server-tls` (Ready: True ✅)
2. The explicit `certificate.enabled: true` in the Helm values creates a *second* Certificate → `argo-cd-argocd-server` (Ready: False ❌)

Both target the same Secret (`argocd-server-tls`), causing a permanent conflict. When Terraform tries to upgrade the ArgoCD chart, it patches this broken Certificate, triggering the cert-manager webhook — which times out because of the conflict state.

## Fix
Disable the explicit `certificate.enabled` in the ArgoCD Helm values. The Ingress annotation already handles TLS cert provisioning correctly.

## After Merge
The stale Certificate resource `argo-cd-argocd-server` should be cleaned up by Helm on the next upgrade. If not:
```bash
kubectl delete certificate argo-cd-argocd-server -n argo-cd
```