### PR TITLE
[codex] migrate homelab domain to vind.uk

### DIFF
--- a/kubernetes/cluster.tf
+++ b/kubernetes/cluster.tf
@@ -21,9 +21,9 @@ module "tailscale-operator" {
 module "cloudflare-tunnel" {
   source                = "../terraform-modules/cloudflare-tunnel"
   cloudflare_account_id = "0c9db0acdf0395f9fef4f94939f2b0c7"
-  cloudflare_zone_id    = "a39b7d8ffa6518631ae4192c80ca4209"
+  cloudflare_zone_id    = "08f8995d9b5928650e61c12ee7f3181a"
   tunnel_name           = "homelab-ha"
-  tunnel_hostnames      = ["*.shrub.dev"]
+  tunnel_hostnames      = ["*.vind.uk"]
 }
 
 # Kubernetes secret for cloudflared running in-cluster

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -11,7 +11,7 @@ variable "cloudflare_api_token" {
 variable "letsencrypt_prod_email" {
   description = "Email address registered with Let's Encrypt for the production ClusterIssuer"
   type        = string
-  default     = "admin@shrub.dev"
+  default     = "admin@vind.uk"
   validation {
     condition     = can(regex("^[^@]+@[^@]+[.][^@]+$", var.letsencrypt_prod_email))
     error_message = "letsencrypt_prod_email must be a valid email address."

--- a/terraform-modules/argo-cd/values.yaml
+++ b/terraform-modules/argo-cd/values.yaml
@@ -41,7 +41,7 @@ server:
     annotations:
       # This lets cert-manager identify which Ingresses to generate a cert for
       cert-manager.io/cluster-issuer: letsencrypt-prod
-    hostname: "argo.shrub.dev"
+    hostname: "argo.vind.uk"
     tls: true
 
   certificate:

--- a/terraform-modules/cert-manager/clusterissuer-letsencrypt-prod.yaml
+++ b/terraform-modules/cert-manager/clusterissuer-letsencrypt-prod.yaml
@@ -1,4 +1,4 @@
-# ClusterIssuer for issuing certificates for shrub.dev via Let's Encrypt DNS-01 validation
+# ClusterIssuer for issuing certificates for vind.uk via Let's Encrypt DNS-01 validation
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -17,4 +17,4 @@ spec:
               key: api-token
         selector:
           dnsZones:
-            - shrub.dev
+            - vind.uk

--- a/terraform-modules/cloudflare-tunnel/main.tf
+++ b/terraform-modules/cloudflare-tunnel/main.tf
@@ -52,7 +52,7 @@ resource "cloudflare_dns_record" "tunnel_cname" {
   for_each = toset(var.tunnel_hostnames)
 
   zone_id = var.cloudflare_zone_id
-  name    = split(".", each.value)[0] # Extract subdomain (e.g., "argo" from "argo.shrub.dev")
+  name    = split(".", each.value)[0] # Extract subdomain (e.g., "argo" from "argo.vind.uk")
   type    = "CNAME"
   content = "${cloudflare_zero_trust_tunnel_cloudflared.homelab_ha.id}.cfargotunnel.com"
   proxied = true

--- a/terraform-modules/cloudflare-tunnel/variables.tf
+++ b/terraform-modules/cloudflare-tunnel/variables.tf
@@ -18,6 +18,6 @@ variable "tunnel_hostnames" {
   description = "List of hostnames to route through the tunnel"
   type        = list(string)
   default = [
-    "argo.shrub.dev",
+    "argo.vind.uk",
   ]
 }


### PR DESCRIPTION
## Summary
- Switch Cloudflare Terraform from the `shrub.dev` zone to the active `vind.uk` zone.
- Route the homelab Cloudflare tunnel wildcard through `*.vind.uk`.
- Update the Argo CD hostname, cert-manager DNS-01 zone selector, and default Let's Encrypt contact email.

## Notes
- Cloudflare was prepared additively before this PR: the existing tunnel now accepts both `*.shrub.dev` and `*.vind.uk`, and app host records were added under `vind.uk`.
- Applying this Terraform change is the actual infra cutover and will make Terraform manage the `vind.uk` wildcard instead of the old `shrub.dev` wildcard.

## Validation
- `terraform fmt -check -recursive`
- `terraform -chdir=kubernetes init -backend=false -input=false`
- `terraform -chdir=kubernetes validate`
- YAML parse check for touched chart values/templates