### PR TITLE
[codex] fix cert-manager webhook networking

### DIFF
--- a/terraform-modules/cert-manager/values.yaml
+++ b/terraform-modules/cert-manager/values.yaml
@@ -42,7 +42,7 @@ tolerations: []
 
 webhook:
   replicaCount: 1
-  timeoutSeconds: 10
+  timeoutSeconds: 30
   strategy: {}
   securityContext:
     runAsNonRoot: true
@@ -81,8 +81,8 @@ webhook:
   serviceAccount:
     create: true
     automountServiceAccountToken: true
-  securePort: 10250
-  hostNetwork: false
+  securePort: 10260
+  hostNetwork: true
   serviceType: ClusterIP
   url: {}
 


### PR DESCRIPTION
## Summary
- Run the cert-manager webhook on host networking so the control-plane API server can reach it when pod-network routing is unavailable from the API server path.
- Move the webhook secure port from `10250` to `10260` to avoid colliding with the kubelet-style port when using host networking.
- Increase the admission webhook timeout from 10s to 30s.

## Why
The `main` apply after #523 failed while updating `letsencrypt-prod` because the Kubernetes API server timed out calling `webhook.cert-manager.io` at `cert-manager-webhook.cert-manager.svc`. The webhook pod was Ready and the service had endpoints, so this is a webhook reachability path issue rather than a Terraform syntax issue.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("terraform-modules/cert-manager/values.yaml")'`
- `terraform -chdir=kubernetes validate`
- `pre-commit run --files terraform-modules/cert-manager/values.yaml --hook-stage manual`