### PR TITLE
[codex] fix K8S module path filter

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -70,6 +70,9 @@ jobs:
             kubernetes:
               - 'kubernetes/**'
               - 'terraform-modules/argo-cd/**'
+              - 'terraform-modules/cert-manager/**'
+              - 'terraform-modules/cloudflare-tunnel/**'
+              - 'terraform-modules/tailscale-operator/**'
               - '.github/workflows/**'
             ansible:
               - 'ansible/tailscale.yml'


### PR DESCRIPTION
## Summary
- Include Kubernetes Terraform module directories in the CI path filter for the `Terraform K8S` job.
- Covers cert-manager, Cloudflare tunnel, and Tailscale operator module changes in addition to the existing Argo CD module path.

## Why
PR #524 changed only `terraform-modules/cert-manager/values.yaml`, so the merged `main` run went green while skipping `Terraform K8S`. As a result, the live cluster still has the previous cert-manager webhook settings and the `letsencrypt-prod` ClusterIssuer is still on `shrub.dev`.

Merging this workflow fix should trigger `Terraform K8S` because workflow files are already in the Kubernetes filter, allowing the pending cert-manager webhook and `vind.uk` ClusterIssuer changes to apply.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/actions.yml")'`
- `pre-commit run --files .github/workflows/actions.yml --hook-stage manual`