### PR TITLE
[codex] harden CI against transient downloads

### DIFF
--- a/.github/actions/setup-sops/action.yml
+++ b/.github/actions/setup-sops/action.yml
@@ -12,12 +12,17 @@ runs:
     - name: Install age
       shell: bash
       run: |
-        curl -sSL https://github.com/FiloSottile/age/releases/download/v1.2.0/age-v1.2.0-linux-amd64.tar.gz | sudo tar -xz -C /usr/local/bin --strip-components=1
+        curl -fSL --retry 5 --retry-all-errors --retry-delay 5 \
+          https://github.com/FiloSottile/age/releases/download/v1.2.0/age-v1.2.0-linux-amd64.tar.gz \
+          -o /tmp/age.tar.gz
+        sudo tar -xzf /tmp/age.tar.gz -C /usr/local/bin --strip-components=1
 
     - name: Install SOPS
       shell: bash
       run: |
-        curl -sSL https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64 -o /tmp/sops
+        curl -fSL --retry 5 --retry-all-errors --retry-delay 5 \
+          https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64 \
+          -o /tmp/sops
         chmod +x /tmp/sops
         sudo mv /tmp/sops /usr/local/bin/sops
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1039,10 +1039,33 @@ jobs:
         if: github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.apply.outcome == 'success'
         run: |
           # plan exit codes: 0=no change, 1=error, 2=changes (drift)
-          set +e
-          terraform plan -detailed-exitcode -out=drift.tfplan
-          code=$?
-          set -e
+          attempts=3
+          delay=20
+          code=1
+          log_file="$(mktemp)"
+          trap 'rm -f "$log_file"' EXIT
+
+          for attempt in $(seq 1 "$attempts"); do
+            : > "$log_file"
+            set +e
+            terraform plan -detailed-exitcode -out=drift.tfplan 2>&1 | tee "$log_file"
+            code=${PIPESTATUS[0]}
+            set -e
+
+            if [ "$code" -ne 1 ]; then
+              break
+            fi
+
+            if ! grep -Eq '504 Gateway Timeout|failed to fetch|Error locating chart' "$log_file"; then
+              break
+            fi
+
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "Terraform drift plan hit a transient chart download error; retrying in ${delay}s (attempt $((attempt + 1))/${attempts})."
+              sleep "$delay"
+            fi
+          done
+
           if [ "$code" -eq 1 ]; then
             echo "Terraform plan encountered an error (exit 1)."
             exit 1


### PR DESCRIPTION
## Summary
- Add `curl --fail` and retries when downloading `age` and `sops` in the shared SOPS setup action.
- Download `age` to a file before extracting so HTTP error pages are not streamed into `tar`.
- Retry the post-apply K8S drift plan when it fails on transient Helm chart download errors such as `504 Gateway Timeout`.

## Why
The `main` run after #525 failed even though `Terraform Apply` for K8S succeeded. The remaining failures were transient external download/fetch issues:
- SOPS setup received a non-gzip response while downloading `age` from GitHub releases.
- K8S drift detection failed after apply because Helm could not fetch the Argo chart release tarball due to a `504 Gateway Timeout`.

The live cluster did receive the domain cutover successfully; this PR only hardens CI so similar transient fetches do not leave successful applies marked red.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/actions/setup-sops/action.yml .github/workflows/actions.yml`
- `pre-commit run --files .github/actions/setup-sops/action.yml .github/workflows/actions.yml --hook-stage manual`