### PR TITLE
fix ingress placement on stanley

### DIFF
--- a/ansible/traefik-helmchart.yaml
+++ b/ansible/traefik-helmchart.yaml
@@ -33,5 +33,7 @@ spec:
     - key: "node-role.kubernetes.io/control-plane"
       operator: "Exists"
       effect: "NoSchedule"
+    nodeSelector:
+      kubernetes.io/hostname: "stanley-arm1"
     service:
       ipFamilyPolicy: "PreferDualStack"


### PR DESCRIPTION
## Summary
- pin Traefik to stanley-arm1 so it can reach the current app backends
- make the live ingress placement fix durable across K3s/Helm reconciles

## Validation
- ruby YAML parse for ansible/traefik-helmchart.yaml
- live Traefik moved to stanley-arm1
- HTTPS checks through Cloudflare returned 200 for adguard, ynab, signoz, map, hey, and argo on vind.uk