### PR TITLE
fix ansible path filter for k3s manifests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -77,6 +77,7 @@ jobs:
             ansible:
               - 'ansible/tailscale.yml'
               - 'ansible/k3s.yml'
+              - 'ansible/*.yaml'
               - 'ansible/playbooks/**'
               - 'ansible/roles/**'
               - 'ansible/group_vars/**'
@@ -444,7 +445,7 @@ jobs:
             SECURITY_CHANGED=true
           fi
 
-          if git diff --name-only origin/main...HEAD | grep -E '^ansible/(k3s\.yml|k3s-master-config\.yaml|roles/k3s[^/]+/|playbooks/k3s\.yml)'; then
+          if git diff --name-only origin/main...HEAD | grep -E '^ansible/(k3s\.yml|k3s-master-config\.yaml|traefik-helmchart\.yaml|roles/k3s[^/]+/|playbooks/k3s\.yml)'; then
             K3S_CHANGED=true
           fi
 


### PR DESCRIPTION
## Summary
- include top-level Ansible YAML manifests in the Ansible path filter
- mark traefik-helmchart.yaml as K3s-related for PR dry-run coverage

## Validation
- Ruby YAML parse for .github/workflows/actions.yml
- pre-commit run --files .github/workflows/actions.yml