### PR TITLE
fix argocd repo-server probe timeout

### DIFF
--- a/terraform-modules/argo-cd/values.yaml
+++ b/terraform-modules/argo-cd/values.yaml
@@ -105,6 +105,11 @@ repoServer:
   autoscaling:
     enabled: false
     minReplicas: 1
+  readinessProbe:
+    timeoutSeconds: 5
+  livenessProbe:
+    failureThreshold: 6
+    timeoutSeconds: 5
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
- increase Argo CD repo-server readiness probe timeout to 5s
- increase repo-server full liveness probe timeout to 5s and failure budget to 6
- match the live operational fix that stopped repo-server liveness restarts

## Validation
- Ruby YAML parse for terraform-modules/argo-cd/values.yaml
- pre-commit run --files terraform-modules/argo-cd/values.yaml
- live repo-server pod stayed 2/2 Running with zero restarts after the old failure window
- Argo apps refreshed back to Synced