### PR TITLE
[codex] Import OpenClaw direct server into Ansible

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -161,6 +161,7 @@ jobs:
             ansible/tailscale.yml
             ansible/k3s.yml
             ansible/playbooks/pis.yml
+            ansible/playbooks/openclaw.yml
             ansible/playbooks/security.yml
             ansible/playbooks/swap.yml
           )
@@ -433,7 +434,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if git diff --name-only origin/main...HEAD | grep -E '^ansible/(playbooks/pis\.yml|roles/(common|network)/|group_vars/pis\.yml)'; then
+          if git diff --name-only origin/main...HEAD | grep -E '^ansible/(playbooks/(pis|openclaw)\.yml|roles/(common|network|openclaw_direct)/|group_vars/pis\.yml|host_vars/jim-pi\.yml)'; then
             PIS_CHANGED=true
           fi
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -30,6 +30,12 @@ Without proper Tailscale route advertisement, UFW rules alone will not enable cr
 
 Configures swap on low-memory nodes (micro_nodes group) to prevent OOM kills.
 
+### openclaw.yml
+
+Configures the direct OpenClaw server on `jim-pi`. OpenClaw intentionally stays outside Kubernetes; Ansible manages the
+npm package, the user-level `openclaw-gateway.service`, and the WhatsApp watchdog timer while preserving runtime state
+and secrets in `~/.openclaw`.
+
 ## Debian Release Upgrades
 
 * The `roles/debian_upgrade` role rewrites APT sources, runs a dist-upgrade, cleans up packages, and reboots the node so we can move Pis between Debian releases via Ansible.

--- a/ansible/host_vars/jim-pi.yml
+++ b/ansible/host_vars/jim-pi.yml
@@ -1,3 +1,4 @@
 ---
 tailscale_ssh_advertise_routes: "10.42.1.0/24"
 os_tuning_dphys_swap_size_mb: "1024"
+openclaw_enabled: true

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -6,6 +6,9 @@
 jim-pi ansible_host=jim-pi ansible_user=akash ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 dwight-pi ansible_host=dwight-pi ansible_user=akash ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
+[openclaw_hosts]
+jim-pi
+
 [oracle_workers]
 stanley-arm1 ansible_host=stanley-arm1 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3.10 ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 angela-amd2 ansible_host=angela-amd2 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3.10 ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/ansible/playbooks/openclaw.yml
+++ b/ansible/playbooks/openclaw.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure OpenClaw direct server
+  hosts: openclaw_hosts
+  become: true
+  roles:
+    - role: ../roles/openclaw_direct

--- a/ansible/playbooks/pis.yml
+++ b/ansible/playbooks/pis.yml
@@ -15,3 +15,4 @@
     - role: ../roles/k3s_prereqs
     - role: ../roles/security
     - role: ../roles/os_tuning
+    - role: ../roles/openclaw_direct

--- a/ansible/roles/openclaw_direct/defaults/main.yml
+++ b/ansible/roles/openclaw_direct/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+openclaw_enabled: false
+openclaw_user: "{{ ansible_user }}"
+openclaw_home: "/home/{{ openclaw_user }}"
+openclaw_state_dir: "{{ openclaw_home }}/.openclaw"
+openclaw_workspace_dir: "{{ openclaw_home }}/openclaw"
+openclaw_npm_prefix: "{{ openclaw_home }}/.npm-global"
+openclaw_version: "2026.5.18"
+openclaw_gateway_port: 18789
+openclaw_gateway_service_name: openclaw-gateway.service
+openclaw_gateway_restart: true
+openclaw_gateway_managed_env_keys:
+  - BRAVE_API_KEY
+  - TAVILY_API_KEY
+openclaw_path_entries:
+  - /usr/bin
+  - "{{ openclaw_home }}/.local/bin"
+  - "{{ openclaw_npm_prefix }}/bin"
+  - "{{ openclaw_home }}/bin"
+  - "{{ openclaw_home }}/.bun/bin"
+  - "{{ openclaw_home }}/.nix-profile/bin"
+  - /usr/local/bin
+  - /bin
+
+openclaw_watchdog_enabled: true
+openclaw_watchdog_interval: 5m
+openclaw_watchdog_on_boot: 2m
+openclaw_watchdog_accuracy: 30s
+openclaw_watchdog_script: "{{ openclaw_home }}/.local/bin/openclaw-whatsapp-watchdog.py"
+openclaw_watchdog_log_path: "{{ openclaw_state_dir }}/watchdog.log"

--- a/ansible/roles/openclaw_direct/handlers/main.yml
+++ b/ansible/roles/openclaw_direct/handlers/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Reload user systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+    scope: user
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ openclaw_user_uid.stdout }}"
+
+- name: Restart OpenClaw gateway
+  ansible.builtin.systemd:
+    name: "{{ openclaw_gateway_service_name }}"
+    state: restarted
+    scope: user
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ openclaw_user_uid.stdout }}"
+  when: openclaw_gateway_restart | bool
+
+- name: Restart OpenClaw watchdog timer
+  ansible.builtin.systemd:
+    name: openclaw-watchdog.timer
+    state: restarted
+    scope: user
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ openclaw_user_uid.stdout }}"
+  when: openclaw_watchdog_enabled | bool

--- a/ansible/roles/openclaw_direct/tasks/main.yml
+++ b/ansible/roles/openclaw_direct/tasks/main.yml
@@ -1,0 +1,139 @@
+---
+- name: Manage OpenClaw direct server
+  when: openclaw_enabled | bool
+  tags: [openclaw]
+  block:
+    - name: Get OpenClaw user uid
+      ansible.builtin.command: "id -u {{ openclaw_user }}"
+      changed_when: false
+      check_mode: false
+      register: openclaw_user_uid
+
+    - name: Enable lingering for OpenClaw user services
+      ansible.builtin.command: "loginctl enable-linger {{ openclaw_user }}"
+      become: true
+      args:
+        creates: "/var/lib/systemd/linger/{{ openclaw_user }}"
+
+    - name: Ensure OpenClaw user directories exist
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "{{ item.mode }}"
+      become: true
+      loop:
+        - path: "{{ openclaw_home }}/.config/systemd/user"
+          mode: "0755"
+        - path: "{{ openclaw_home }}/.local/bin"
+          mode: "0755"
+        - path: "{{ openclaw_state_dir }}"
+          mode: "0700"
+        - path: "{{ openclaw_workspace_dir }}"
+          mode: "0755"
+        - path: "{{ openclaw_npm_prefix }}"
+          mode: "0755"
+
+    - name: Check npm availability
+      ansible.builtin.command: npm --version
+      changed_when: false
+      check_mode: false
+      register: openclaw_npm_version
+
+    - name: Install OpenClaw npm package
+      community.general.npm:
+        name: openclaw
+        version: "{{ openclaw_version }}"
+        global: true
+      become: true
+      become_user: "{{ openclaw_user }}"
+      environment:
+        NPM_CONFIG_PREFIX: "{{ openclaw_npm_prefix }}"
+        PATH: "{{ openclaw_path_entries | join(':') }}"
+      notify: Restart OpenClaw gateway
+
+    - name: Link OpenClaw into /usr/bin for host scripts
+      ansible.builtin.file:
+        src: "{{ openclaw_npm_prefix }}/lib/node_modules/openclaw/openclaw.mjs"
+        dest: /usr/bin/openclaw
+        state: link
+        owner: root
+        group: root
+        force: true
+      become: true
+
+    - name: Deploy OpenClaw gateway user service
+      ansible.builtin.template:
+        src: openclaw-gateway.service.j2
+        dest: "{{ openclaw_home }}/.config/systemd/user/{{ openclaw_gateway_service_name }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0644"
+      become: true
+      notify:
+        - Reload user systemd
+        - Restart OpenClaw gateway
+
+    - name: Deploy OpenClaw WhatsApp watchdog script
+      ansible.builtin.template:
+        src: openclaw-whatsapp-watchdog.py.j2
+        dest: "{{ openclaw_watchdog_script }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0755"
+      become: true
+      when: openclaw_watchdog_enabled | bool
+      notify: Restart OpenClaw watchdog timer
+
+    - name: Deploy OpenClaw watchdog service
+      ansible.builtin.template:
+        src: openclaw-watchdog.service.j2
+        dest: "{{ openclaw_home }}/.config/systemd/user/openclaw-watchdog.service"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0644"
+      become: true
+      when: openclaw_watchdog_enabled | bool
+      notify:
+        - Reload user systemd
+        - Restart OpenClaw watchdog timer
+
+    - name: Deploy OpenClaw watchdog timer
+      ansible.builtin.template:
+        src: openclaw-watchdog.timer.j2
+        dest: "{{ openclaw_home }}/.config/systemd/user/openclaw-watchdog.timer"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0644"
+      become: true
+      when: openclaw_watchdog_enabled | bool
+      notify:
+        - Reload user systemd
+        - Restart OpenClaw watchdog timer
+
+    - name: Flush OpenClaw handlers before enabling units
+      ansible.builtin.meta: flush_handlers
+
+    - name: Enable and start OpenClaw gateway
+      ansible.builtin.systemd:
+        name: "{{ openclaw_gateway_service_name }}"
+        enabled: true
+        state: started
+        scope: user
+      become: true
+      become_user: "{{ openclaw_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ openclaw_user_uid.stdout }}"
+
+    - name: Enable and start OpenClaw watchdog timer
+      ansible.builtin.systemd:
+        name: openclaw-watchdog.timer
+        enabled: true
+        state: started
+        scope: user
+      become: true
+      become_user: "{{ openclaw_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ openclaw_user_uid.stdout }}"
+      when: openclaw_watchdog_enabled | bool

--- a/ansible/roles/openclaw_direct/templates/openclaw-gateway.service.j2
+++ b/ansible/roles/openclaw_direct/templates/openclaw-gateway.service.j2
@@ -1,0 +1,29 @@
+[Unit]
+Description=OpenClaw Gateway (v{{ openclaw_version }})
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+[Service]
+ExecStart=/usr/bin/node {{ openclaw_npm_prefix }}/lib/node_modules/openclaw/dist/index.js gateway --port {{ openclaw_gateway_port }}
+Restart=always
+RestartSec=5
+RestartPreventExitStatus=78
+TimeoutStopSec=30
+TimeoutStartSec=30
+SuccessExitStatus=0 143
+KillMode=control-group
+Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS={{ openclaw_gateway_managed_env_keys | join(',') }}
+Environment=HOME={{ openclaw_home }}
+Environment=TMPDIR=/tmp
+Environment=PATH={{ openclaw_path_entries | join(':') }}
+Environment=OPENCLAW_GATEWAY_PORT={{ openclaw_gateway_port }}
+Environment=OPENCLAW_SYSTEMD_UNIT={{ openclaw_gateway_service_name }}
+Environment="OPENCLAW_WINDOWS_TASK_NAME=OpenClaw Gateway"
+Environment=OPENCLAW_SERVICE_MARKER=openclaw
+Environment=OPENCLAW_SERVICE_KIND=gateway
+Environment=OPENCLAW_SERVICE_VERSION={{ openclaw_version }}
+
+[Install]
+WantedBy=default.target

--- a/ansible/roles/openclaw_direct/templates/openclaw-watchdog.service.j2
+++ b/ansible/roles/openclaw_direct/templates/openclaw-watchdog.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=OpenClaw WhatsApp watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 {{ openclaw_watchdog_script }}

--- a/ansible/roles/openclaw_direct/templates/openclaw-watchdog.timer.j2
+++ b/ansible/roles/openclaw_direct/templates/openclaw-watchdog.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run OpenClaw WhatsApp watchdog periodically
+
+[Timer]
+OnBootSec={{ openclaw_watchdog_on_boot }}
+OnUnitActiveSec={{ openclaw_watchdog_interval }}
+AccuracySec={{ openclaw_watchdog_accuracy }}
+Unit=openclaw-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/openclaw_direct/templates/openclaw-whatsapp-watchdog.py.j2
+++ b/ansible/roles/openclaw_direct/templates/openclaw-whatsapp-watchdog.py.j2
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+OPENCLAW = "/usr/bin/openclaw"
+LOG_PATH = "{{ openclaw_watchdog_log_path }}"
+
+
+def ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def log(msg: str) -> None:
+    os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+    with open(LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(f"[{ts()}] {msg}\n")
+
+
+def run(cmd: list[str], timeout_s: int = 20) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, text=True, capture_output=True, timeout=timeout_s)
+
+
+def resolve(host: str) -> str:
+    try:
+        infos = socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+        addrs = sorted({i[4][0] for i in infos})
+        return "ok " + ",".join(addrs)
+    except Exception as e:
+        return f"error {type(e).__name__}: {e}"
+
+
+def parse_status_output(stdout: str) -> dict:
+    """OpenClaw can prepend notices before JSON; parse the final JSON object."""
+    try:
+        return json.loads(stdout)
+    except Exception:
+        pass
+
+    match = re.search(r"\{[\s\S]*\}\s*$", stdout)
+    if not match:
+        raise ValueError("no trailing JSON object in status output")
+    return json.loads(match.group(0))
+
+
+def main() -> int:
+    try:
+        p = run([OPENCLAW, "channels", "status", "--json", "--timeout", "10000"], timeout_s=15)
+    except subprocess.TimeoutExpired:
+        log("timeout: openclaw channels status")
+        return 1
+
+    if p.returncode != 0:
+        log(f"error: openclaw channels status rc={p.returncode} stderr={p.stderr.strip()}")
+        return 1
+
+    try:
+        data = parse_status_output(p.stdout)
+    except Exception as e:
+        preview = " ".join((p.stdout or "").splitlines()[:3]).strip()
+        log(f"error: parse status json: {type(e).__name__}: {e}; preview={preview!r}")
+        return 1
+
+    wa = (data.get("channels") or {}).get("whatsapp") or {}
+
+    configured = bool(wa.get("configured"))
+    linked = bool(wa.get("linked"))
+    running = bool(wa.get("running"))
+    connected = bool(wa.get("connected"))
+    last_error = wa.get("lastError")
+
+    if configured and linked and running and connected:
+        return 0
+
+    dns = resolve("web.whatsapp.com")
+    log(
+        "unhealthy: whatsapp "
+        + f"configured={configured} linked={linked} running={running} connected={connected} "
+        + f"dns=({dns}) lastError={json.dumps(last_error)}"
+    )
+
+    try:
+        r = run([OPENCLAW, "gateway", "restart"], timeout_s=30)
+        if r.returncode == 0:
+            log("action: gateway restart ok")
+            return 0
+        log(f"action: gateway restart failed rc={r.returncode} stderr={r.stderr.strip()}")
+        return 2
+    except subprocess.TimeoutExpired:
+        log("action: gateway restart timed out")
+        return 2
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        log(f"fatal: {type(e).__name__}: {e}")
+        sys.exit(3)


### PR DESCRIPTION
## Summary

- Add an `openclaw_direct` Ansible role to manage the direct OpenClaw install on `jim-pi`.
- Add a targeted `ansible/playbooks/openclaw.yml` playbook and include the role in the normal Pi playbook.
- Keep OpenClaw outside Kubernetes while managing the npm package, `/usr/bin/openclaw` link, user systemd gateway service, and WhatsApp watchdog timer.
- Update CI syntax-check coverage and PR dry-run detection for the new playbook/role.

## Validation

- `ansible-playbook --syntax-check` for `ansible/playbooks/openclaw.yml`
- `ansible-playbook --syntax-check` for `ansible/playbooks/pis.yml`
- `ansible-lint ansible/playbooks/openclaw.yml ansible/playbooks/pis.yml`
- `git diff --check`
- Applied `ansible/playbooks/openclaw.yml --limit jim-pi` successfully
- Re-ran check mode idempotently: `changed=0`
- Verified `openclaw-gateway.service` active on `jim-pi`
- Verified `openclaw channels status` reports WhatsApp healthy/connected

## Notes

OpenClaw state and secrets remain on the host under `~/.openclaw`; this PR does not move OpenClaw into Kubernetes or commit runtime credentials.