### PR TITLE
chore(k3s): bump k3s to v1.35.4+k3s1

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,6 +1,6 @@
 ---
 # Managed by Renovate (k3s-io/k3s tags)
-k3s_version: "v1.35.3+k3s1"
+k3s_version: "v1.35.4+k3s1"
 k3s_master_ip: "100.100.1.100"
 k3s_master_port: "6443"
 


### PR DESCRIPTION
## Summary
- Bump the Renovate-managed K3S version pin from `v1.35.3+k3s1` to `v1.35.4+k3s1`.
- Verified `v1.35.4+k3s1` is a published non-prerelease upstream K3S release.
- Kept this to the next stable patch release in the existing v1.35 line instead of jumping to v1.36.

Upstream release: https://github.com/k3s-io/k3s/releases/tag/v1.35.4%2Bk3s1

## Verification
- `git diff --check`
- Local Ansible/yamllint tooling is not installed on this host, so CI should run the full syntax/lint checks.