### PR TITLE
[codex] Fix Ansible UFW IPv6 preflight

### DIFF
--- a/ansible/roles/firewall/tasks/main.yml
+++ b/ansible/roles/firewall/tasks/main.yml
@@ -50,6 +50,33 @@
   when: not (ansible_distribution == "Debian" and ansible_distribution_release == "trixie")
   tags: [firewall, ufw]
 
+- name: Check whether UFW IPv6 is enabled
+  ansible.builtin.command: grep -qs ^IPV6=yes /etc/default/ufw
+  register: ufw_ipv6_enabled_check
+  changed_when: false
+  failed_when: false
+  become: true
+  tags: [firewall, ufw]
+
+- name: Check UFW IPv6 user chain
+  ansible.builtin.command: ip6tables -L ufw6-user-input -n
+  register: ufw_ipv6_user_chain_check
+  changed_when: false
+  failed_when: false
+  become: true
+  when: ufw_ipv6_enabled_check.rc == 0
+  tags: [firewall, ufw]
+
+- name: Restore UFW IPv6 user chains when missing
+  ansible.builtin.command: ip6tables-restore --noflush /etc/ufw/user6.rules
+  register: ufw_ipv6_user_chain_restore
+  changed_when: ufw_ipv6_user_chain_restore.rc == 0
+  become: true
+  when:
+    - ufw_ipv6_enabled_check.rc == 0
+    - ufw_ipv6_user_chain_check.rc | default(0) != 0
+  tags: [firewall, ufw]
+
 - name: Reset UFW to default state
   community.general.ufw:
     state: reset


### PR DESCRIPTION
## Summary

- Repair missing UFW IPv6 secondary runtime chains before the firewall role invokes `community.general.ufw`.
- Repeat the chain repair immediately before `ufw -f enable`, because `ufw reset` can leave the runtime IPv6 logging/rate-limit chains incomplete until enable.
- Keep the existing UFW reset/rebuild flow intact once UFW's expected chains are readable.

## Root Cause

The failed `Ansible Security` job on run `26219899450` stopped on `toby-gcp1` because UFW had `IPV6=yes`, but the runtime IPv6 UFW chain set was incomplete. The first failure was `ufw status verbose` failing with `ERROR: problem running ip6tables`; the next retry progressed further but failed at enable with `ERROR: Could not load logging rules` because UFW IPv6 logging/rate-limit secondary chains were still missing after reset.

## Validation

- `ANSIBLE_CONFIG=ansible/ansible.cfg /tmp/homelab-ansible-venv-pr/bin/ansible-playbook --syntax-check -i ansible/hosts.ini ansible/playbooks/security.yml`
- `/tmp/homelab-ansible-venv-pr/bin/ansible-lint ansible/roles/firewall/tasks/main.yml`
- `pre-commit run yamllint --files ansible/roles/firewall/tasks/main.yml`
- `ANSIBLE_CONFIG=ansible/ansible.cfg /tmp/homelab-ansible-venv-pr/bin/ansible-playbook -i ansible/hosts.ini ansible/playbooks/security.yml --limit toby-gcp1 --tags firewall`
- Commit pre-commit hooks passed: gitleaks, detect-secrets, ansible-lint, yamllint