### PR TITLE
Fix Argo CD SOPS plugin

### DIFF
--- a/terraform-modules/argo-cd/argo-cd.tf
+++ b/terraform-modules/argo-cd/argo-cd.tf
@@ -37,9 +37,9 @@ resource "kubernetes_config_map_v1" "argocd_cmp" {
                   *) cat "$f"; echo "---" ;;
                 esac
               done
-              # Decrypt and output encrypted files via AVP (recursive)
+              # Decrypt and output encrypted files via SOPS (recursive)
               find . -name '*.enc.yaml' -type f | while read -r f; do
-                argocd-vault-plugin generate "$f"
+                sops -d "$f"
                 echo "---"
               done
         lockRepo: false

--- a/terraform-modules/argo-cd/values.yaml
+++ b/terraform-modules/argo-cd/values.yaml
@@ -151,9 +151,12 @@ repoServer:
         - |
           ARCH=$$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
           AVP_VERSION=1.18.1
+          SOPS_VERSION=3.13.0
           wget -O /custom-tools/argocd-vault-plugin \
             "https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$${AVP_VERSION}/argocd-vault-plugin_$${AVP_VERSION}_linux_$${ARCH}"
-          chmod +x /custom-tools/argocd-vault-plugin
+          wget -O /custom-tools/sops \
+            "https://github.com/getsops/sops/releases/download/v$${SOPS_VERSION}/sops-v$${SOPS_VERSION}.linux.$${ARCH}"
+          chmod +x /custom-tools/argocd-vault-plugin /custom-tools/sops
       volumeMounts:
         - name: custom-tools
           mountPath: /custom-tools
@@ -179,6 +182,9 @@ repoServer:
         - name: custom-tools
           mountPath: /usr/local/bin/argocd-vault-plugin
           subPath: argocd-vault-plugin
+        - name: custom-tools
+          mountPath: /usr/local/bin/sops
+          subPath: sops
         - name: sops-age
           mountPath: /sops/age
 


### PR DESCRIPTION
## Summary
- install the SOPS binary into the Argo CD repo-server CMP sidecar
- render encrypted manifests with sops -d instead of calling argocd-vault-plugin without a vault type
- keep the existing recursive non-secret manifest rendering behavior

## Validation
- terraform fmt -check terraform-modules/argo-cd
- terraform validate terraform-modules/argo-cd
- pre-commit hooks run during commit: secret scans, terraform fmt/validate, ansible-lint, yamllint
- live media recovery confirmed qBittorrent 2/2 Running after applying the decrypted gluetun-vpn secret