### PR TITLE
Manage Argo CD SOPS age key

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -849,6 +849,8 @@ jobs:
           tags: tag:k3s
 
       - name: Decrypt secrets
+        env:
+          SOPS_AGE_SECRET_KEY: ${{ secrets.SOPS_AGE_SECRET_KEY }}
         run: |
           cd ${{ github.workspace }}
           # Decrypt secrets - use printf %b to convert \n to actual newlines
@@ -864,9 +866,10 @@ jobs:
           TF_VAR_velero_s3_secret_key="$(sops -d --extract '["velero_s3_secret_key"]' secrets/terraform.yaml)"
           TF_VAR_openai_api_key="$(sops -d --extract '["openai_api_key"]' secrets/terraform.yaml)"
           TF_VAR_homelab_map_interactive_password="$(sops -d --extract '["homelab_map_interactive_password"]' secrets/terraform.yaml)"
+          TF_VAR_sops_age_secret_key="$SOPS_AGE_SECRET_KEY"
           TF_API_TOKEN="$(sops -d --extract '["api_token"]' secrets/terraform.yaml)"
           # Mask each line of multiline secrets
-          for secret in "$TF_VAR_kube_client_cert" "$TF_VAR_kube_client_key" "$TF_VAR_kube_cluster_ca_cert"; do
+          for secret in "$TF_VAR_kube_client_cert" "$TF_VAR_kube_client_key" "$TF_VAR_kube_cluster_ca_cert" "$TF_VAR_sops_age_secret_key"; do
             while IFS= read -r line; do
               [ -n "$line" ] && echo "::add-mask::$line"
             done <<< "$secret"
@@ -888,6 +891,9 @@ jobs:
           echo "TF_VAR_kube_cluster_ca_cert<<EOFCA" >> $GITHUB_ENV
           echo "$TF_VAR_kube_cluster_ca_cert" >> $GITHUB_ENV
           echo "EOFCA" >> $GITHUB_ENV
+          echo "TF_VAR_sops_age_secret_key<<EOFSOPSAGE" >> $GITHUB_ENV
+          echo "$TF_VAR_sops_age_secret_key" >> $GITHUB_ENV
+          echo "EOFSOPSAGE" >> $GITHUB_ENV
           echo "TF_VAR_cloudflare_api_token=$TF_VAR_cloudflare_api_token" >> $GITHUB_ENV
           echo "TF_VAR_tailscale_oauth_client_secret=$TF_VAR_tailscale_oauth_client_secret" >> $GITHUB_ENV
           echo "TF_VAR_velero_s3_access_key=$TF_VAR_velero_s3_access_key" >> $GITHUB_ENV

--- a/kubernetes/cluster.tf
+++ b/kubernetes/cluster.tf
@@ -1,5 +1,7 @@
 module "argo-cd" {
-  source     = "../terraform-modules/argo-cd"
+  source              = "../terraform-modules/argo-cd"
+  sops_age_secret_key = var.sops_age_secret_key
+
   depends_on = [module.cert-manager]
 }
 

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -112,3 +112,13 @@ variable "homelab_map_interactive_password" {
     error_message = "Interactive password cannot be empty."
   }
 }
+
+variable "sops_age_secret_key" {
+  description = "AGE private key used by Argo CD to decrypt SOPS-encrypted manifests"
+  type        = string
+  sensitive   = true
+  validation {
+    condition     = length(var.sops_age_secret_key) > 0
+    error_message = "SOPS AGE private key cannot be empty."
+  }
+}

--- a/terraform-modules/argo-cd/argo-cd.tf
+++ b/terraform-modules/argo-cd/argo-cd.tf
@@ -30,6 +30,8 @@ resource "kubernetes_config_map_v1" "argocd_cmp" {
             - sh
             - "-c"
             - |
+              set -eu
+
               # Output non-encrypted yamls (recursive)
               find . -name '*.yaml' -type f | while read -r f; do
                 case "$f" in
@@ -51,6 +53,23 @@ resource "kubernetes_config_map_v1" "argocd_cmp" {
   ]
 }
 
+resource "kubernetes_secret_v1" "sops_age_key" {
+  metadata {
+    name      = "sops-age-key"
+    namespace = kubernetes_namespace_v1.argo-cd.metadata[0].name
+  }
+
+  data = {
+    "keys.txt" = var.sops_age_secret_key
+  }
+
+  type = "Opaque"
+
+  depends_on = [
+    kubernetes_namespace_v1.argo-cd
+  ]
+}
+
 resource "helm_release" "argo-cd" {
   name       = "argo-cd"
   namespace  = "argo-cd"
@@ -61,7 +80,8 @@ resource "helm_release" "argo-cd" {
   values = [templatefile("${path.module}/values.yaml", {})]
 
   depends_on = [
-    kubernetes_namespace_v1.argo-cd
+    kubernetes_namespace_v1.argo-cd,
+    kubernetes_secret_v1.sops_age_key
   ]
 }
 

--- a/terraform-modules/argo-cd/variables.tf
+++ b/terraform-modules/argo-cd/variables.tf
@@ -1,0 +1,10 @@
+variable "sops_age_secret_key" {
+  description = "AGE private key used by Argo CD to decrypt SOPS-encrypted manifests."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.sops_age_secret_key) > 0
+    error_message = "sops_age_secret_key cannot be empty."
+  }
+}


### PR DESCRIPTION
## Summary
- manage the Argo CD `sops-age-key` Secret from Terraform instead of relying on a manually-created cluster Secret
- pass the existing GitHub `SOPS_AGE_SECRET_KEY` into the Kubernetes Terraform workflow as `TF_VAR_sops_age_secret_key`
- fail the `avp-sops` CMP render on decrypt errors with `set -eu`

## Validation
- `terraform -chdir=kubernetes init`
- `terraform -chdir=kubernetes init -backend=false`
- `terraform -chdir=kubernetes validate`
- pre-commit hooks from commit: secret scans, terraform fmt, terraform validate, ansible-lint, yamllint
- live repo-server decrypts `homelab-deployments/src/media/gluetun-vpn.enc.yaml` with the mounted key
- media app is Synced/Healthy at `ad1d9a7d466d921e70075969a726d26334637ae7`
- `media/gluetun-vpn` has Argo tracking + ServerSideApply annotations and no `last-applied-configuration` annotation
- confirmed `terraform-modules/argo-cd/values.yaml` mounts `sops-age-key` at `/sops/age` and sets `SOPS_AGE_KEY_FILE=/sops/age/keys.txt`
- imported existing live Secret into Terraform state: `module.argo-cd.kubernetes_secret_v1.sops_age_key`