### PR TITLE
Fix Argo CD homelab deployments repo URL

### DIFF
--- a/terraform-modules/argo-cd/argo-cd-apps-values.yaml
+++ b/terraform-modules/argo-cd/argo-cd-apps-values.yaml
@@ -3,7 +3,7 @@ applications:
     namespace: argo-cd
     project: default
     source:
-      repoURL: https://github.com/slashr/app-manifests.git
+      repoURL: https://github.com/slashr/homelab-deployments.git
       targetRevision: "main"
       path: "argo"
       directory:

--- a/terraform-modules/argo-cd/values.yaml
+++ b/terraform-modules/argo-cd/values.yaml
@@ -201,6 +201,6 @@ configs:
       url: https://stefanprodan.github.io/podinfo
       name: podinfo
       type: helm
-    app-manifests-repo:
-      url: https://github.com/slashr/app-manifests.git
-      name: app-manifests
+    homelab-deployments-repo:
+      url: https://github.com/slashr/homelab-deployments.git
+      name: homelab-deployments


### PR DESCRIPTION
## Summary

- Switch the Argo CD app-of-apps source from the old renamed `slashr/app-manifests` URL to `slashr/homelab-deployments`.
- Update the Argo CD repository entry name and URL to match the current repository.

## Why

`slashr/homelab-deployments` is now private. The old public rename redirect from `app-manifests` masked the stale bootstrap URL, but private repositories should use the canonical repo URL directly so Argo CD can apply the configured GitHub credentials reliably.

## Validation

- Updated the live `argo-cd/argocd-repo-creds-github-slashr` repo credential Secret with a valid HTTPS token and removed its sensitive `kubectl.kubernetes.io/last-applied-configuration` annotation.
- Patched the live `app-of-apps` Application to `https://github.com/slashr/homelab-deployments.git` and hard-refreshed it successfully.
- Changed `slashr/homelab-deployments` visibility to private.
- Hard-refreshed Argo CD applications after the visibility change; all Git-backed apps are `Synced` with no repository-access conditions.
- Commit hooks passed: hardcoded secrets, detect-secrets, ansible-lint, yamllint.