### PR TITLE
Manage Argo CD GitHub repo credentials

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -866,6 +866,7 @@ jobs:
           TF_VAR_velero_s3_secret_key="$(sops -d --extract '["velero_s3_secret_key"]' secrets/terraform.yaml)"
           TF_VAR_openai_api_key="$(sops -d --extract '["openai_api_key"]' secrets/terraform.yaml)"
           TF_VAR_homelab_map_interactive_password="$(sops -d --extract '["homelab_map_interactive_password"]' secrets/terraform.yaml)"
+          TF_VAR_argocd_github_token="$(sops -d --extract '["argocd_github_token"]' secrets/terraform.yaml)"
           TF_VAR_sops_age_secret_key="$SOPS_AGE_SECRET_KEY"
           TF_API_TOKEN="$(sops -d --extract '["api_token"]' secrets/terraform.yaml)"
           # Mask each line of multiline secrets
@@ -880,6 +881,7 @@ jobs:
           echo "::add-mask::$TF_VAR_velero_s3_secret_key"
           echo "::add-mask::$TF_VAR_openai_api_key"
           echo "::add-mask::$TF_VAR_homelab_map_interactive_password"
+          echo "::add-mask::$TF_VAR_argocd_github_token"
           echo "::add-mask::$TF_API_TOKEN"
           # Write to GITHUB_ENV
           echo "TF_VAR_kube_client_cert<<EOFCERT" >> $GITHUB_ENV
@@ -900,6 +902,7 @@ jobs:
           echo "TF_VAR_velero_s3_secret_key=$TF_VAR_velero_s3_secret_key" >> $GITHUB_ENV
           echo "TF_VAR_openai_api_key=$TF_VAR_openai_api_key" >> $GITHUB_ENV
           echo "TF_VAR_homelab_map_interactive_password=$TF_VAR_homelab_map_interactive_password" >> $GITHUB_ENV
+          echo "TF_VAR_argocd_github_token=$TF_VAR_argocd_github_token" >> $GITHUB_ENV
           echo "TF_API_TOKEN=$TF_API_TOKEN" >> $GITHUB_ENV
           # Note: tailscale_oauth_client_id comes from kubernetes/terraform.tfvars
 

--- a/kubernetes/cluster.tf
+++ b/kubernetes/cluster.tf
@@ -1,8 +1,14 @@
 module "argo-cd" {
   source              = "../terraform-modules/argo-cd"
+  github_token        = var.argocd_github_token
   sops_age_secret_key = var.sops_age_secret_key
 
   depends_on = [module.cert-manager]
+}
+
+import {
+  to = module.argo-cd.kubernetes_secret_v1.github_repo_creds
+  id = "argo-cd/argocd-repo-creds-github-slashr"
 }
 
 module "cert-manager" {

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -113,6 +113,16 @@ variable "homelab_map_interactive_password" {
   }
 }
 
+variable "argocd_github_token" {
+  description = "GitHub token used by Argo CD to read private slashr repositories"
+  type        = string
+  sensitive   = true
+  validation {
+    condition     = length(var.argocd_github_token) > 0
+    error_message = "Argo CD GitHub token cannot be empty."
+  }
+}
+
 variable "sops_age_secret_key" {
   description = "AGE private key used by Argo CD to decrypt SOPS-encrypted manifests"
   type        = string

--- a/secrets/terraform.yaml
+++ b/secrets/terraform.yaml
@@ -21,10 +21,10 @@ velero_s3_secret_key: ENC[AES256_GCM,data:lbTW2/EnKzl/0aVFIhDHRV5g8bde7uGz6sqi0q
 openai_api_key: ENC[AES256_GCM,data:aaSq+82xHHCjyBb3Kt36RzvCPbp6LHCDiHkwmOfzwlj95xcyOe6sKLydHBAXKZDSCTzaC7JMbXs9ZqYWitk1Hfi+zghQdDxacUWeYfAUhTQVOC+CgwP6gqOVyNP5FUeF/mC4HjNY8uybse7Mg45UiParCO4dvqYwVG6yu4WcCiPEo35TPMIYQtZ6Kfsh6LUoEnStGA5juu1bljErO0/71BYV0EY=,iv:yU01gMc3yFi31eC4sofhaYCOZU1vAxSgxf0Yo/0yRRw=,tag:h7afZjpWiQ2ZX20arqNWdQ==,type:str]
 #ENC[AES256_GCM,data:mFr5PnOMmN4sY9Fa+iI4UYuuNmAX6HDk3J19BJ1nVqf8Q/JiMC8HmJCZ0VYIKu6v5SJQrxrG,iv:6ZmCCuuerTl4jlby81G6XdP7WzFB6bVgx6wseUivtO8=,tag:SbwmswCHylnEoWLDT4kU2A==,type:comment]
 homelab_map_interactive_password: ENC[AES256_GCM,data:4xu4SSMB+Z/lGFT1+o4=,iv:/OZIy79Ld6RtPILYFbUTyldf7dLobaHKlwf27rZb0do=,tag:DdDaofARo22DsBb8Df6f9Q==,type:str]
+argocd_github_token: ENC[AES256_GCM,data:f9kuU0p4ytWSCosR6nipGW9MvBOCkuh6QTlVity+Hu3uchFXc2SLzT8Xs7uP3oCfWjXtamyIxX1FYQ0y9x+GEGVsvV6oDDZ62hIEdN1wOeKHnLGuc6eRBzL6SaRE,iv:j9viSQYM56xtzROaCelSJg7b0pSC1H0PnH9ur69IbiU=,tag:gPmV0D/WL0wA0CClyroCLQ==,type:str]
 sops:
     age:
-        - recipient: age1p58f02kktcn4t0qrnnqf4jgx2z0xc9e60jxqffk2jxvcecgheylsp8g9qv
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHaFJTbStHNEh4aE9NeHJY
             ZVNLS1VDd0ZFZWtmYnRHZitpOCs2UzMzUVVRCnFXdThWQXltYnUwMW8yQ2ZBTnBF
@@ -32,7 +32,8 @@ sops:
             Vlk2dmtzcUl6Ykd5TmNlTnE0NDhsZDAKNeOmijZ0iOH564mL+IU1CFsU1kAM7oGh
             BTRtNOqCDtV2JNBCFFK3+SQ1adZUN1aaDHPjR1LjZkqsBSErtWUnkQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-17T22:31:55Z"
-    mac: ENC[AES256_GCM,data:+sTll64tZKhcO8/IxQu7zaxx0ur0AMMtfHVuo13uU0OexAsgzj/ycSm1O5a/6u++N1U5oCiNR4IOCIuOZX9InxqsvcHX83EmA/SeclEaOy3EHtnyLcFrltf9TWk6tA9dlPsahibeFX5DAFwOEcxBLX5a6JsEPNw1COzE0v/XQL4=,iv:trhhzfzRqEeyff9ikwvqjqxNUPwTPQfa9Rfen/Q+aNM=,tag:KQuSSotxw8vBHvhmAokK5Q==,type:str]
+          recipient: age1p58f02kktcn4t0qrnnqf4jgx2z0xc9e60jxqffk2jxvcecgheylsp8g9qv
+    lastmodified: "2026-06-03T08:30:30Z"
+    mac: ENC[AES256_GCM,data:LHdQWOJoyPzWK5tIiOfJV1J22ZTtRG9Up6a66pYl06cMg+UvE7JBZxouYtGBqcrWx+DYjXJP6C51SbBDnDyMLJ51ffOIs9OomqYEVmJ8+lEg+3Noz4Jn3iIOfDxHL7OaaPTUrk7xN7RVCFEcL5F02Ohkq7FL+a0RGhfX6/Rco5s=,iv:b2s3WCyh19v4jSmqoDNDbczDgDW8ovKZAvAo6KbFZsA=,tag:ALlr5kEpHe2HO0Uh9VOzhw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/terraform-modules/argo-cd/argo-cd.tf
+++ b/terraform-modules/argo-cd/argo-cd.tf
@@ -70,6 +70,29 @@ resource "kubernetes_secret_v1" "sops_age_key" {
   ]
 }
 
+resource "kubernetes_secret_v1" "github_repo_creds" {
+  metadata {
+    name      = "argocd-repo-creds-github-slashr"
+    namespace = kubernetes_namespace_v1.argo-cd.metadata[0].name
+    labels = {
+      "argocd.argoproj.io/secret-type" = "repo-creds"
+    }
+  }
+
+  data = {
+    type     = "git"
+    url      = "https://github.com/slashr"
+    username = "slashr"
+    password = var.github_token
+  }
+
+  type = "Opaque"
+
+  depends_on = [
+    kubernetes_namespace_v1.argo-cd
+  ]
+}
+
 resource "helm_release" "argo-cd" {
   name       = "argo-cd"
   namespace  = "argo-cd"

--- a/terraform-modules/argo-cd/variables.tf
+++ b/terraform-modules/argo-cd/variables.tf
@@ -8,3 +8,14 @@ variable "sops_age_secret_key" {
     error_message = "sops_age_secret_key cannot be empty."
   }
 }
+
+variable "github_token" {
+  description = "GitHub token used by Argo CD to read private slashr repositories."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.github_token) > 0
+    error_message = "github_token cannot be empty."
+  }
+}


### PR DESCRIPTION
## Summary

- Add `argocd_github_token` to the SOPS-encrypted Terraform secrets file.
- Pass the token through the Kubernetes Terraform workflow as `TF_VAR_argocd_github_token`.
- Manage the Argo CD GitHub repo credential Secret from the Argo CD Terraform module.
- Add a Terraform import block so the existing live `argo-cd/argocd-repo-creds-github-slashr` Secret is adopted instead of recreated.

## Why

`slashr/homelab-deployments` is now private. Argo CD already has a working live repo credential, but it was manually managed. This makes the credential reproducible through the normal SOPS + Terraform path.

## Validation

- `sops -d secrets/terraform.yaml | yq '{"has_argocd_github_token": has("argocd_github_token"), "key_count": (keys | length)}' -`
- `terraform -chdir=kubernetes fmt -check`
- `terraform -chdir=terraform-modules/argo-cd fmt -check`
- `terraform -chdir=kubernetes init -input=false`
- `terraform -chdir=kubernetes validate`
- `pre-commit run --files .github/workflows/actions.yml kubernetes/cluster.tf kubernetes/variables.tf secrets/terraform.yaml terraform-modules/argo-cd/argo-cd.tf terraform-modules/argo-cd/variables.tf`

Note: the token value is encrypted in SOPS and not present in plaintext in the repository.