### PR TITLE
Upgrade tailscale-operator chart 1.92.4 -> 1.98.4

### DIFF
--- a/terraform-modules/tailscale-operator/variables.tf
+++ b/terraform-modules/tailscale-operator/variables.tf
@@ -7,7 +7,7 @@ variable "namespace" {
 variable "chart_version" {
   description = "The Helm chart version to install"
   type        = string
-  default     = "1.92.4"
+  default     = "1.98.4"
 }
 
 variable "timeout" {


### PR DESCRIPTION
The v1.92.4 ingress proxies cap every tailnet HTTPS service at ~20 KB/s (delayed-ACK lockstep in the userspace TCP path; measured identically on the inab and webtop ingresses regardless of node, file, or HTTP version). 1.98.x carries the netstack throughput fixes — confirmed by pinning the inab proxy to v1.98.5 via ProxyClass before rolling this fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)