### PR TITLE
chore(deps): update k3s to v1.36.1

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,6 +1,6 @@
 ---
 # Managed by Renovate (k3s-io/k3s tags)
-k3s_version: "v1.35.4+k3s1"
+k3s_version: "v1.36.1+k3s1"
 k3s_master_ip: "100.100.1.100"
 k3s_master_port: "6443"
 


### PR DESCRIPTION
## Summary
- Update the homelab Ansible k3s pin from `v1.35.4+k3s1` to `v1.36.1+k3s1`
- Verified `v1.36.1+k3s1` is the current upstream GitHub release and is not marked prerelease

Release: https://github.com/k3s-io/k3s/releases/tag/v1.36.1%2Bk3s1

## Validation
- `pre-commit run --files ansible/group_vars/all.yml`