### PR TITLE
fix(tailscale): use OAuth client secret for k3s VPN auth (non-expiring)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Configures SSH for Tailscale SSH connections. Verifies Tailscale is connected an
 ### GitHub Actions Secrets (Required)
 
 * `SOPS_AGE_SECRET_KEY` — AGE private key for decrypting SOPS-encrypted secrets
-* `TAILSCALE_JOIN_KEY` — Auth key for node registration (used by Ansible k3s playbook)
+* `TAILSCALE_JOIN_KEY` — Tailscale OAuth client secret (`tskey-client-…`, `auth_keys` write, tag `tag:k3s`) for node registration; non-expiring (replaces the static auth key that wedged k3s on reboot)
 
 ### SOPS-Encrypted Secrets
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ This Homelab is a k3s cluster made up of of Oracle Cloud Infrastructure VMs, a G
 * K3S installs by default the Traefik networking and ingress controller. Traefik exposes Services of type
   LoadBalancer on the RPi private IP and routes HTTP traffic to the right Ingress. It effectively replaces
   ingress-nginx and MetalLB, simplifying the setup.
-* Tailscale creates a mesh network between all servers. The auth key is stored as `TAILSCALE_JOIN_KEY` in GitHub
-  Secrets, exported for the Ansible job in `actions.yml`, and referenced in `k3s.yaml` via the `--vpn-auth` flag
+* Tailscale creates a mesh network between all servers. `TAILSCALE_JOIN_KEY` is a Tailscale **OAuth client secret**
+  (`tskey-client-…`, `auth_keys` write scope, tag `tag:k3s`) stored in GitHub Secrets, exported for the Ansible job
+  in `actions.yml`, and referenced in `k3s.yaml` via the `--vpn-auth` flag (with `--advertise-tags=tag:k3s`). An OAuth
+  secret is used instead of a static auth key because auth keys expire (≤90 days), which wedges k3s on the next reboot;
+  OAuth secrets don't expire and k3s mints a fresh key from it on every start
   when initializing k3s on the master and worker nodes.
 
 ## Notes

--- a/ansible/k3s.yml
+++ b/ansible/k3s.yml
@@ -76,7 +76,7 @@
 
     - name: Installing k3s
       ansible.builtin.command: >
-        /tmp/k3s.sh --vpn-auth="name=tailscale,joinKey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}"
+        /tmp/k3s.sh --vpn-auth="name=tailscale,joinKey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}?ephemeral=false&preauthorized=true,extraArgs=--advertise-tags=tag:k3s"
       environment:
         INSTALL_K3S_VERSION: "{{ k3s_version }}"
       register: k3s_install
@@ -199,7 +199,7 @@
 
     - name: Installing k3s agent
       ansible.builtin.command: >
-        /tmp/k3s.sh --vpn-auth="name=tailscale,joinKey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}"
+        /tmp/k3s.sh --vpn-auth="name=tailscale,joinKey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}?ephemeral=false&preauthorized=true,extraArgs=--advertise-tags=tag:k3s"
       environment:
         K3S_TOKEN: "{{ agent_token_fact }}"
         K3S_URL: "https://{{ k3s_master_ip }}:{{ k3s_master_port }}"

--- a/ansible/tailscale.yml
+++ b/ansible/tailscale.yml
@@ -55,7 +55,7 @@
       failed_when: false
 
     - name: Configure Tailscale with join key
-      ansible.builtin.command: tailscale up --authkey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }} --ssh --accept-risk=lose-ssh
+      ansible.builtin.command: tailscale up --authkey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}?ephemeral=false&preauthorized=true --advertise-tags=tag:k3s --ssh --accept-risk=lose-ssh
       when:
         - lookup('env', 'TAILSCALE_JOIN_KEY') is defined
         - lookup('env', 'TAILSCALE_JOIN_KEY') | length > 0


### PR DESCRIPTION
## Problem

The k3s integrated Tailscale VPN baked a **static auth key** into the unit file (`joinKey=`). Tailscale auth keys expire after ≤90 days, and k3s re-runs `tailscale up --authkey` on **every start** — so the first reboot after the key expires wedges the whole cluster. The control plane binds its API to the tailnet IP, so k3s can't start at all without Tailscale → total outage (this is what took down `*.vind.uk`).

"Disable key expiry" in the Tailscale console does **not** help: that toggle is the *node key* (device identity), not the *auth key* baked into the unit. The auth key is only exercised at startup, so a dead key sits harmless until the next (re)boot.

## Fix

Use a Tailscale **OAuth client secret** (`tskey-client-…`, `auth_keys` write scope, `tag:k3s`) as `TAILSCALE_JOIN_KEY`. OAuth secrets don't expire; k3s mints a fresh short-lived key from it on every start. OAuth-minted keys require tags, so:

- `ansible/k3s.yml` — add `extraArgs=--advertise-tags=tag:k3s` to `--vpn-auth`, and `?ephemeral=false&preauthorized=true` to the join key (persistent, pre-approved)
- `ansible/tailscale.yml` — add `--advertise-tags=tag:k3s` (+ same query params) to the `tailscale up` call
- `ansible/roles/tailscale_ssh/*` — already advertises `tag:k3s`, no change needed
- `README.md` / `AGENTS.md` — document that `TAILSCALE_JOIN_KEY` is now an OAuth client secret

## Rollout status

- **Live nodes already migrated and verified**: michael-pi (control plane), jim-pi, dwight-pi — all restarted cleanly on the OAuth secret, rejoined as `tag:k3s`, nodes Ready, `prowl.vind.uk` healthy (302). Original unit files backed up as `*.bak.preoauth` on each.
- **Cloud workers** (toby/pam/angela/stanley) still on the old key; they pick this up on the next Ansible run (or can be migrated live).

## ⚠️ Action required (out of band)

Update the GitHub Actions secret **`TAILSCALE_JOIN_KEY`** to the OAuth client secret value, or the next CI/Ansible run will revert nodes to the (now-deleted) static key.

## Related

Companion to #548 (ACL: allow pod/service CIDRs as sources). Together these make a reboot/re-auth non-destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)