### PR TITLE
fix(k3s): enable Tailscale SSH in k3s vpn-auth (--ssh in extraArgs)

### DIFF
--- a/ansible/k3s.yml
+++ b/ansible/k3s.yml
@@ -76,7 +76,7 @@
 
     - name: Installing k3s
       ansible.builtin.command: >
-        /tmp/k3s.sh --vpn-auth="name=tailscale,joinKey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}?ephemeral=false&preauthorized=true,extraArgs=--advertise-tags=tag:k3s"
+        /tmp/k3s.sh --vpn-auth="name=tailscale,joinKey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}?ephemeral=false&preauthorized=true,extraArgs=--advertise-tags=tag:k3s --ssh"
       environment:
         INSTALL_K3S_VERSION: "{{ k3s_version }}"
       register: k3s_install
@@ -199,7 +199,7 @@
 
     - name: Installing k3s agent
       ansible.builtin.command: >
-        /tmp/k3s.sh --vpn-auth="name=tailscale,joinKey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}?ephemeral=false&preauthorized=true,extraArgs=--advertise-tags=tag:k3s"
+        /tmp/k3s.sh --vpn-auth="name=tailscale,joinKey={{ lookup('env', 'TAILSCALE_JOIN_KEY') }}?ephemeral=false&preauthorized=true,extraArgs=--advertise-tags=tag:k3s --ssh"
       environment:
         K3S_TOKEN: "{{ agent_token_fact }}"
         K3S_URL: "https://{{ k3s_master_ip }}:{{ k3s_master_port }}"


### PR DESCRIPTION
## Problem

The deploy run after the OAuth migration (#549) failed: **Ansible Tailscale** reported `jim-pi` and `michael-pi` as `UNREACHABLE / akash@…: Permission denied (publickey)`, while dwight + all cloud nodes succeeded.

Root cause: the CI runner connects via **Tailscale SSH**. jim and michael had `RunSSH=false`. When k3s does a *full* `tailscale up` (which happens when the node is logged out — e.g. the OAuth re-auth during the outage recovery), it applies only the flags in `vpn-auth` extraArgs and resets the rest. Without `--ssh`, that leaves Tailscale SSH **off**, so the runner falls back to key-based SSH and is denied.

(Note: `tailscale.yml` already runs `tailscale up --ssh`, but that only runs during a deploy. k3s's own VPN bring-up on reboot/re-auth is the gap.)

## Fix

Add `--ssh` to the k3s `--vpn-auth` `extraArgs`, so k3s re-enables Tailscale SSH whenever it brings the VPN up:

```
extraArgs=--advertise-tags=tag:k3s --ssh
```

## Verification

- Applied live to michael-pi, jim-pi, dwight-pi (`tailscale set --ssh` now; this commit makes it durable across re-auths). All three: `RunSSH=true`, reachable via Tailscale SSH, nodes Ready.
- Re-ran the failed workflow: **Ansible Tailscale** now passes with `unreachable=0` on all 7 nodes; Ansible Pis/Security proceed.
- `prowl.vind.uk` healthy (302) throughout.

## Series

Final piece alongside #548 (ACL pod-CIDR sources) and #549 (OAuth client secret). Together: a reboot or re-auth no longer wedges the cluster *or* locks CI out of the nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)